### PR TITLE
refactor ci-cd: split trigger dev and prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,13 +27,3 @@ jobs:
           script: |
             echo "Check Konsulin API Container Status..."
             docker ps -a | grep "konsulin-api" || echo "Container not found or SSH failed"
-
-      - name: Trigger Coolify Deploy
-        run: |
-          if [ -n "${{ secrets.COOLIFY_TRIGGER_URL }}" ] && [ -n "${{ secrets.COOLIFY_TOKEN }}" ]; then
-            echo "Triggering Coolify deployment..."
-            curl "${{ secrets.COOLIFY_TRIGGER_URL }}" \
-              --header "Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}"
-          else
-            echo "Coolify secrets not provided. Skipping deployment trigger."
-            exit 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,15 +29,31 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
   # Deploy to appropriate environment
-  deploy:
-    name: Deploy Application
+  deploy-dev:
+    name: Deploy to Dev (Coolify)
     needs: docker
-    if: ${{ github.ref_name == 'develop' || startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ github.ref_name == 'develop' }}
+    uses: ./.github/workflows/trigger-coolify.yml
+    secrets:
+      COOLIFY_TRIGGER_URL: ${{ secrets.COOLIFY_TRIGGER_URL_DEV }}
+      COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN_DEV }}
+
+  deploy-prod:
+    name: Deploy to Prod (Coolify)
+    needs: docker
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    uses: ./.github/workflows/trigger-coolify.yml
+    secrets:
+      COOLIFY_TRIGGER_URL: ${{ secrets.COOLIFY_TRIGGER_URL_PROD }}
+      COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN_PROD }}
+  
+  deploy-check:
+    name: Check Konsulin API Container Status
+    needs: [deploy-dev, deploy-prod]
+    if: ${{ always() }}
     uses: ./.github/workflows/deploy.yml
     secrets:
       SSH_HOST: ${{ secrets.SSH_HOST }}
       SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
       SSH_KEY: ${{ secrets.SSH_KEY }}
-      COOLIFY_TRIGGER_URL: ${{ secrets.COOLIFY_TRIGGER_URL }}
-      COOLIFY_TOKEN: ${{ secrets.COOLIFY_TOKEN }}
 

--- a/.github/workflows/trigger-coolify.yml
+++ b/.github/workflows/trigger-coolify.yml
@@ -1,0 +1,19 @@
+name: Trigger Coolify Deploy
+
+on:
+  workflow_call:
+    secrets:
+      COOLIFY_TRIGGER_URL:
+        required: true
+      COOLIFY_TOKEN:
+        required: true
+
+jobs:
+  trigger-coolify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Coolify Deploy
+        run: |
+          echo "Triggering Coolify deployment..."
+          curl "${{ secrets.COOLIFY_TRIGGER_URL }}" \
+            --header "Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}"


### PR DESCRIPTION
Description
This PR adds new secrets required for triggering Coolify deployments via GitHub Actions:

COOLIFY_TRIGGER_URL_DEV

COOLIFY_TOKEN_DEV

COOLIFY_TRIGGER_URL_PROD

COOLIFY_TOKEN_PROD

These will be used in CI/CD workflows to deploy to development and production environments.