### PR TITLE
fix: add necessary rbac policy for super admin for sesi temu feature

### DIFF
--- a/resources/rbac_policy.csv
+++ b/resources/rbac_policy.csv
@@ -52,4 +52,6 @@ p, superadmin, PractitionerRole, PUT
 p, superadmin, Questionnaire, POST
 p, superadmin, ResearchStudy, POST
 p, superadmin, QuestionnaireResponse, GET
-p, superadmin, Observation, GET
+p, superadmin, Condition, PUT
+p, superadmin, Slot, PUT
+p, superadmin, Appointment, POST


### PR DESCRIPTION
adding these necessary rbac policy:

<pre>p, superadmin, Condition, PUT
p, superadmin, Slot, PUT
p, superadmin, Appointment, POST</pre>

and remove unused policy
`p, superadmin, Observation, GET`

after doing quick regression testing on local, all the expected feature accessible by super admin still works fine, in addition now super admin can perform this feature: `Choose the date and time. Send the request after the user completed the form.` on `/fhir` endpoint as a `bundle request`