### PR TITLE
fix: add response filtering to check bundled response's resource

### DIFF
--- a/internal/app/delivery/http/middlewares/proxy.go
+++ b/internal/app/delivery/http/middlewares/proxy.go
@@ -2,15 +2,19 @@ package middlewares
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"konsulin-service/internal/pkg/constvars"
 	"konsulin-service/internal/pkg/exceptions"
 	"konsulin-service/internal/pkg/utils"
+
+	"go.uber.org/zap"
 )
 
 func (m *Middlewares) Bridge(target string) http.Handler {
@@ -53,15 +57,177 @@ func (m *Middlewares) Bridge(target string) http.Handler {
 				return
 			}
 
-			fhirErr := exceptions.BuildNewCustomError(fmt.Errorf(string(body)), resp.StatusCode, string(body), constvars.ErrDevServerProcess)
+			fhirErr := exceptions.BuildNewCustomError(fmt.Errorf("%s", string(body)), resp.StatusCode, string(body), constvars.ErrDevServerProcess)
 			utils.BuildErrorResponse(m.Log, w, fhirErr)
 			return
 		}
 
+		// Read the entire response body for potential filtering
+		respBody, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			utils.BuildErrorResponse(m.Log, w, exceptions.ErrReadBody(readErr))
+			return
+		}
+
+		// Determine if we should filter based on roles
+		roles, _ := r.Context().Value(keyRoles).([]string)
+		filteringRole := determineFilteringRole(roles)
+
+		// Early return for non-filtered responses
+		if filteringRole == "" {
+			// No filtering needed - return response immediately
+			for k, v := range resp.Header {
+				w.Header()[k] = v
+			}
+			w.WriteHeader(resp.StatusCode)
+			if _, err := w.Write(respBody); err != nil {
+				m.Log.Warn("failed writing response body", zap.Error(err))
+			}
+			return
+		}
+
+		// Apply filtering for superadmin (and future roles)
+		var filteredBody []byte
+		var removedCount int
+		var filtered bool
+		switch filteringRole {
+		case constvars.KonsulinRoleSuperadmin:
+			if b, removed, err := m.filterResponseResourceAgainsRBAC(respBody, roles); err == nil {
+				removedCount = removed
+				if removed > 0 {
+					filtered = true
+				}
+				filteredBody = b
+			} else {
+				// If filtering fails, fall back to original body
+				m.Log.Warn("response filtering failed; returning original body", zap.Error(err))
+				filteredBody = respBody
+			}
+		default:
+			// This shouldn't happen given our early return, but safety first
+			filteredBody = respBody
+		}
+
+		if filtered && removedCount > 0 {
+			m.Log.Info("RBAC filtered response entries",
+				zap.Int("removed", removedCount),
+				zap.String("method", r.Method),
+				zap.String("url", r.URL.RequestURI()),
+				zap.Strings("roles", roles),
+			)
+		}
+
+		// Copy headers, but recalculate Content-Length if body changed
 		for k, v := range resp.Header {
+			// We'll set Content-Length ourselves
+			if strings.EqualFold(k, "Content-Length") {
+				continue
+			}
 			w.Header()[k] = v
 		}
+		// Remove ETag if body has been modified to avoid inconsistencies
+		if filtered {
+			w.Header().Del("ETag")
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(filteredBody)))
 		w.WriteHeader(resp.StatusCode)
-		io.Copy(w, resp.Body)
+		if _, err := w.Write(filteredBody); err != nil {
+			m.Log.Warn("failed writing response body", zap.Error(err))
+		}
 	})
+}
+
+// determineFilteringRole returns the primary role for which response filtering should apply.
+// For now, we only filter for superadmin requests. When empty string return, it means no filtering should be applied.
+func determineFilteringRole(roles []string) string {
+	for _, role := range roles {
+		if strings.EqualFold(role, constvars.KonsulinRoleSuperadmin) {
+			return constvars.KonsulinRoleSuperadmin
+		}
+	}
+	return ""
+}
+
+// filterResponseResourceAgainsRBAC removes any Bundle.entry resources that are not allowed by RBAC.
+// If the response is not a Bundle or JSON cannot be parsed, it returns the original body unchanged.
+// It returns the possibly filtered body and the count of removed entries.
+func (m *Middlewares) filterResponseResourceAgainsRBAC(body []byte, roles []string) ([]byte, int, error) {
+	// Quick check: parse resourceType
+	var envelope struct {
+		ResourceType string `json:"resourceType"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return body, 0, nil // Non-JSON or unknown format; leave untouched
+	}
+
+	if !strings.EqualFold(envelope.ResourceType, "Bundle") {
+		// For now, we do not alter singular resources
+		return body, 0, nil
+	}
+
+	// Minimal Bundle structure focusing on entries
+	type entry struct {
+		FullURL  string          `json:"fullUrl,omitempty"`
+		Resource json.RawMessage `json:"resource"`
+		Search   map[string]any  `json:"search,omitempty"`
+	}
+	var bundle struct {
+		ResourceType string  `json:"resourceType"`
+		ID           string  `json:"id,omitempty"`
+		Type         string  `json:"type,omitempty"`
+		Total        *int    `json:"total,omitempty"`
+		Link         any     `json:"link,omitempty"`
+		Entry        []entry `json:"entry"`
+	}
+
+	if err := json.Unmarshal(body, &bundle); err != nil {
+		return body, 0, nil // Malformed JSON; do not risk altering
+	}
+
+	removed := 0
+	filtered := make([]entry, 0, len(bundle.Entry))
+	for _, e := range bundle.Entry {
+		// Identify the resourceType inside entry.resource
+		var resEnv struct {
+			ResourceType string `json:"resourceType"`
+		}
+		if err := json.Unmarshal(e.Resource, &resEnv); err != nil {
+			// If cannot determine type, keep entry to avoid accidental data loss
+			filtered = append(filtered, e)
+			continue
+		}
+
+		if resEnv.ResourceType == "" {
+			filtered = append(filtered, e)
+			continue
+		}
+
+		// Check RBAC: allow if any role permits GET on this resource type
+		allowedForAnyRole := false
+		for _, role := range roles {
+			if allowed(m.Enforcer, role, resEnv.ResourceType, http.MethodGet) {
+				allowedForAnyRole = true
+				break
+			}
+		}
+		if allowedForAnyRole {
+			filtered = append(filtered, e)
+		} else {
+			removed++
+		}
+	}
+
+	// If nothing was removed, return original body to minimize header churn
+	if removed == 0 {
+		return body, 0, nil
+	}
+
+	// Update entries only; keep other fields intact
+	bundle.Entry = filtered
+	filteredBody, err := json.Marshal(bundle)
+	if err != nil {
+		return body, 0, err
+	}
+
+	return filteredBody, removed, nil
 }


### PR DESCRIPTION
to make all returned resource in bundled response still align with RBAC policies. thus, if bundle response include a resource forbidden by the requester role, it will be removed

my local setup database don't have enough data to test this behavior, but I can still test the functionality by injecting an arbitrary response to simulate resource deletion if actor didn't have the required rbac policy.

first, I override the response from actual fhir server
<pre>testJSON := `{"resourceType":"Bundle","id":"DGGPVSSVBJIYT3GV","type":"searchset","total":1,"link":[{"relation":"first","url":"https://dev-blaze.konsulin.care/fhir/QuestionnaireResponse/__page/AQAACvsF7c2VqmqUaHdtmfCap7des4K0EkM0ZRiFMAxVXoQ4CVo7JzkC8C6hTkm4B1vDNdKGPvt03eVRXWkgX18rednQZyLJI6JV0ZtfYRV5NHGl8G9rsEEIKxJKQuVw8zV7YdokBr8PIdZ1J657w6XMjAnzJHDf7rRtZ1Uj7Uy7-YWqcvCr5wav4BCvF8TYIqckEFjDmIrQOkRC85ER15y_Rkhloc1Q2mCtyGu2xX4rEQ-nAoD6cp2CHH685Dug5A"},{"relation":"self","url":"https://dev-blaze.konsulin.care/fhir/QuestionnaireResponse?questionnaire=https%3A%2F%2Fapp.konsulin.care%2Fassessments%2FQuestionnaire-id&_include=QuestionnaireResponse%3Apatient&_elements=subject%2Cauthor&_count=50"}],"entry":[{"fullUrl":"https://dev-blaze.konsulin.care/fhir/QuestionnaireResponse/QuestionnaireResponse-id","resource":{"resourceType":"QuestionnaireResponse","id":"QuestionnaireResponse-id","meta":{"versionId":"1509","lastUpdated":"2025-08-07T18:50:12.550Z","tag":[{"system":"http://terminology.hl7.org/CodeSystem/v3-ObservationValue","code":"SUBSETTED"}]},"subject":{"reference":"Patient/Patient-id"},"author":{"reference":"Practitioner/Practitioner-id"}},"search":{"mode":"match"}},{"fullUrl":"https://dev-blaze.konsulin.care/fhir/Patient/Patient-id","resource":{"resourceType":"Patient","id":"Patient-id","meta":{"versionId":"720","lastUpdated":"2025-04-22T22:04:30.074Z"},"identifier":[{"system":"https://login.konsulin.care/userid","value":"patient-uuid"}],"active":true,"name":[{"use":"official","family":"Pasien","given":["Nama"]}],"telecom":[{"system":"phone","value":"+62-251-9876543","use":"mobile"},{"system":"email","value":"pasien@gmail.com","use":"home"}],"gender":"male","birthDate":"1990-02-21","address":[{"use":"home","type":"physical","line":["Jl. Lenteng Agung No. 10"],"city":"Kota Adm. Jakarta Selatan","district":"Jagakarsa","postalCode":"16127","country":"ID"}],"photo":[{"url":"https://s3.konsulin.care/img/patient/patient-id.png"}]},"search":{"mode":"include"}}]}`
		respBody := []byte(testJSON)</pre>

then, when response is received at the requester:

request
<pre>
curl --location 'http://localhost:8000/fhir/QuestionnaireResponse?questionnaire=https%3A%2F%2Fapp.konsulin.care%2Fassessments%2FQuestionnaire-id&_elements=subject%2Cauthor&_include=QuestionnaireResponse%3Apatient' \
--header 'x-api-key: aduhaiapikey'</pre>

response
<pre>
{
    "resourceType": "Bundle",
    "id": "DGGPVSSVBJIYT3GV",
    "type": "searchset",
    "total": 1,
    "link": [
        {
            "relation": "first",
            "url": "https://dev-blaze.konsulin.care/fhir/QuestionnaireResponse/__page/AQAACvsF7c2VqmqUaHdtmfCap7des4K0EkM0ZRiFMAxVXoQ4CVo7JzkC8C6hTkm4B1vDNdKGPvt03eVRXWkgX18rednQZyLJI6JV0ZtfYRV5NHGl8G9rsEEIKxJKQuVw8zV7YdokBr8PIdZ1J657w6XMjAnzJHDf7rRtZ1Uj7Uy7-YWqcvCr5wav4BCvF8TYIqckEFjDmIrQOkRC85ER15y_Rkhloc1Q2mCtyGu2xX4rEQ-nAoD6cp2CHH685Dug5A"
        },
        {
            "relation": "self",
            "url": "https://dev-blaze.konsulin.care/fhir/QuestionnaireResponse?questionnaire=https%3A%2F%2Fapp.konsulin.care%2Fassessments%2FQuestionnaire-id&_include=QuestionnaireResponse%3Apatient&_elements=subject%2Cauthor&_count=50"
        }
    ],
    "entry": [
        {
            "fullUrl": "https://dev-blaze.konsulin.care/fhir/QuestionnaireResponse/QuestionnaireResponse-id",
            "resource": {
                "resourceType": "QuestionnaireResponse",
                "id": "QuestionnaireResponse-id",
                "meta": {
                    "versionId": "1509",
                    "lastUpdated": "2025-08-07T18:50:12.550Z",
                    "tag": [
                        {
                            "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
                            "code": "SUBSETTED"
                        }
                    ]
                },
                "subject": {
                    "reference": "Patient/Patient-id"
                },
                "author": {
                    "reference": "Practitioner/Practitioner-id"
                }
            },
            "search": {
                "mode": "match"
            }
        }
    ]
}
</pre>

the Patient resource is not deleted. However, If I were to add GET Patient policy for super admin, the response still include the allowed resource

<pre>{
    "resourceType": "Bundle",
    "id": "DGGPVSSVBJIYT3GV",
    "type": "searchset",
    "total": 1,
    "link": [
        {
            "relation": "first",
            "url": "https://dev-blaze.konsulin.care/fhir/QuestionnaireResponse/__page/AQAACvsF7c2VqmqUaHdtmfCap7des4K0EkM0ZRiFMAxVXoQ4CVo7JzkC8C6hTkm4B1vDNdKGPvt03eVRXWkgX18rednQZyLJI6JV0ZtfYRV5NHGl8G9rsEEIKxJKQuVw8zV7YdokBr8PIdZ1J657w6XMjAnzJHDf7rRtZ1Uj7Uy7-YWqcvCr5wav4BCvF8TYIqckEFjDmIrQOkRC85ER15y_Rkhloc1Q2mCtyGu2xX4rEQ-nAoD6cp2CHH685Dug5A"
        },
        {
            "relation": "self",
            "url": "https://dev-blaze.konsulin.care/fhir/QuestionnaireResponse?questionnaire=https%3A%2F%2Fapp.konsulin.care%2Fassessments%2FQuestionnaire-id&_include=QuestionnaireResponse%3Apatient&_elements=subject%2Cauthor&_count=50"
        }
    ],
    "entry": [
        {
            "fullUrl": "https://dev-blaze.konsulin.care/fhir/QuestionnaireResponse/QuestionnaireResponse-id",
            "resource": {
                "resourceType": "QuestionnaireResponse",
                "id": "QuestionnaireResponse-id",
                "meta": {
                    "versionId": "1509",
                    "lastUpdated": "2025-08-07T18:50:12.550Z",
                    "tag": [
                        {
                            "system": "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
                            "code": "SUBSETTED"
                        }
                    ]
                },
                "subject": {
                    "reference": "Patient/Patient-id"
                },
                "author": {
                    "reference": "Practitioner/Practitioner-id"
                }
            },
            "search": {
                "mode": "match"
            }
        },
        {
            "fullUrl": "https://dev-blaze.konsulin.care/fhir/Patient/Patient-id",
            "resource": {
                "resourceType": "Patient",
                "id": "Patient-id",
                "meta": {
                    "versionId": "720",
                    "lastUpdated": "2025-04-22T22:04:30.074Z"
                },
                "identifier": [
                    {
                        "system": "https://login.konsulin.care/userid",
                        "value": "patient-uuid"
                    }
                ],
                "active": true,
                "name": [
                    {
                        "use": "official",
                        "family": "Pasien",
                        "given": [
                            "Nama"
                        ]
                    }
                ],
                "telecom": [
                    {
                        "system": "phone",
                        "value": "+62-251-9876543",
                        "use": "mobile"
                    },
                    {
                        "system": "email",
                        "value": "pasien@gmail.com",
                        "use": "home"
                    }
                ],
                "gender": "male",
                "birthDate": "1990-02-21",
                "address": [
                    {
                        "use": "home",
                        "type": "physical",
                        "line": [
                            "Jl. Lenteng Agung No. 10"
                        ],
                        "city": "Kota Adm. Jakarta Selatan",
                        "district": "Jagakarsa",
                        "postalCode": "16127",
                        "country": "ID"
                    }
                ],
                "photo": [
                    {
                        "url": "https://s3.konsulin.care/img/patient/patient-id.png"
                    }
                ]
            },
            "search": {
                "mode": "include"
            }
        }
    ]
}</pre>

log when resource filtering applied
<pre>{"level":"INFO","time":"2025/08/22 04:13:30","caller":"middlewares/api_key_middleware.go:40","msg":"API Key authentication successful","ip":"[::1]:40162","endpoint":"/fhir/QuestionnaireResponse","method":"GET","user_agent":"PostmanRuntime/7.45.0"}
{"level":"INFO","time":"2025/08/22 04:13:30","caller":"middlewares/proxy.go:116","msg":"RBAC filtered response entries","removed":1,"method":"GET","url":"/fhir/QuestionnaireResponse?questionnaire=https://app.konsulin.care/assessments/Questionnaire-id&_elements=subject,author&_include=QuestionnaireResponse:patient","roles":["superadmin"]}</pre>