### PR TITLE
Feat/webhook integration

### DIFF
--- a/internal/app/config/boostrap.go
+++ b/internal/app/config/boostrap.go
@@ -19,9 +19,15 @@ type Bootstrap struct {
 	Minio          *minio.Client
 	InternalConfig *InternalConfig
 	DriverConfig   *DriverConfig
+	// WorkerStop if set will be called during Shutdown to gracefully stop background workers
+	WorkerStop func()
 }
 
 func (b *Bootstrap) Shutdown(ctx context.Context) error {
+	if b.WorkerStop != nil {
+		b.WorkerStop()
+		log.Println("Successfully stopped background workers")
+	}
 	err := b.Redis.Close()
 	if err != nil {
 		return err

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -71,8 +71,9 @@ func loadInternalConfigWithEnv() *InternalConfig {
 			ForgotPasswordTokenExpiredTimeInMinutes:  utils.GetEnvInt("APP_FORGOT_PASSWORD_TOKEN_EXPIRED_TIME_IN_MINUTES", 0),
 			MinioPreSignedUrlObjectExpiryTimeInHours: utils.GetEnvInt("APP_MINIO_PRE_SIGNED_URL_OBJECT_EXPIRY_TIME_IN_HOURS", 0),
 			QuestionnaireGuestResponseExpiredTimeInMinutes: utils.GetEnvInt("APP_QUESTIONNAIRE_GUEST_RESPONSE_EXPIRED_TIME_IN_MINUTES", 0),
-			SuperadminAPIKey:          utils.GetEnvString("SUPERADMIN_API_KEY", ""),
-			SuperadminAPIKeyRateLimit: utils.GetEnvInt("SUPERADMIN_API_KEY_RATE_LIMIT", 100),
+			SuperadminAPIKey:           utils.GetEnvString("SUPERADMIN_API_KEY", ""),
+			SuperadminAPIKeyRateLimit:  utils.GetEnvInt("SUPERADMIN_API_KEY_RATE_LIMIT", 100),
+			WebhookInstantiateBasePath: utils.GetEnvString("APP_WEBHOOK_INSTANTIATE_BASE_PATH", "/api/v1/hook"),
 		},
 		FHIR: AppFHIR{
 			BaseUrl: utils.GetEnvString("APP_FHIR_BASE_URL", ""),

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -120,6 +120,17 @@ func loadInternalConfigWithEnv() *InternalConfig {
 			PerformanceReportBasePrice: utils.GetEnvInt("BASE_PRICE_PERFORMANCE_REPORT", 0),
 			AccessDatasetBasePrice:     utils.GetEnvInt("BASE_PRICE_ACCESS_DATASET", 0),
 		},
+		Webhook: AppWebhook{
+			RateLimit:            utils.GetEnvInt("HOOK_RATE_LIMIT", 0),
+			MonthlyQuota:         utils.GetEnvInt("HOOK_QUOTA", 0),
+			RateLimitedServices:  utils.GetEnvString("HOOK_RATE_LIMITED_SERVICES", ""),
+			MaxQueue:             utils.GetEnvInt("HOOK_MAX_QUEUE", 1),
+			ThrottleRetry:        utils.GetEnvInt("HOOK_THROTTLE_RETRY", 15),
+			URL:                  utils.GetEnvString("HOOK_URL", ""),
+			HTTPTimeoutInSeconds: utils.GetEnvInt("HOOK_HTTP_TIMEOUT", 10),
+			JWTAlg:               utils.GetEnvString("HOOK_JWT_ALG", "ES256"),
+			JWTHookKey:           utils.GetEnvString("JWT_HOOK_KEY", ""),
+		},
 	}
 
 	// this is a safe guard to ensure that no base price is left unset

--- a/internal/app/config/internal.go
+++ b/internal/app/config/internal.go
@@ -40,6 +40,7 @@ type App struct {
 	QuestionnaireGuestResponseExpiredTimeInMinutes int    `mapstructure:"questionnaire_guest_response_expired_time_in_minutes"`
 	SuperadminAPIKey                               string `mapstructure:"superadmin_api_key"`
 	SuperadminAPIKeyRateLimit                      int    `mapstructure:"superadmin_api_key_rate_limit"`
+	WebhookInstantiateBasePath                     string `mapstructure:"webhook_instantiate_base_path"`
 }
 
 type AppFHIR struct {

--- a/internal/app/config/internal.go
+++ b/internal/app/config/internal.go
@@ -12,6 +12,7 @@ type InternalConfig struct {
 	Supertoken     AppSupertoken     `mapstructure:"supertoken"`
 	PaymentGateway AppPaymentGateway `mapstructure:"payment_gateway"`
 	ServicePricing AppServicePricing `mapstructure:"service_pricing"`
+	Webhook        AppWebhook        `mapstructure:"webhook"`
 }
 
 type App struct {
@@ -96,4 +97,26 @@ type AppServicePricing struct {
 	ReportBasePrice            int `mapstructure:"report_base_price"`
 	PerformanceReportBasePrice int `mapstructure:"performance_report_base_price"`
 	AccessDatasetBasePrice     int `mapstructure:"access_dataset_base_price"`
+}
+
+// AppWebhook holds configuration for the Webhook Service Integration feature.
+type AppWebhook struct {
+	// RateLimit is the number of allowed requests per 60-second window (by service name)
+	RateLimit int `mapstructure:"rate_limit"`
+	// MonthlyQuota is the number of allowed requests per calendar month UTC (by service name)
+	MonthlyQuota int `mapstructure:"monthly_quota"`
+	// RateLimitedServices is a CSV list of service names subject to rate limiting
+	RateLimitedServices string `mapstructure:"rate_limited_services"`
+	// MaxQueue defines how many items the worker processes per tick
+	MaxQueue int `mapstructure:"max_queue"`
+	// ThrottleRetry is the failedCount threshold before sending to DLQ
+	ThrottleRetry int `mapstructure:"throttle_retry"`
+	// URL is the base URL of the external webhook service
+	URL string `mapstructure:"url"`
+	// HTTPTimeoutInSeconds is the HTTP client timeout when calling the webhook
+	HTTPTimeoutInSeconds int `mapstructure:"http_timeout_in_seconds"`
+	// JWTAlg selects the signing algorithm (ES256|RS256)
+	JWTAlg string `mapstructure:"jwt_alg"`
+	// JWTHookKey is the private key PEM for signing webhook JWTs
+	JWTHookKey string `mapstructure:"jwt_hook_key"`
 }

--- a/internal/app/delivery/http/controllers/webhook_controller.go
+++ b/internal/app/delivery/http/controllers/webhook_controller.go
@@ -1,0 +1,123 @@
+package controllers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"konsulin-service/internal/app/config"
+	"konsulin-service/internal/app/services/core/webhook"
+	"konsulin-service/internal/app/services/shared/ratelimiter"
+	"konsulin-service/internal/pkg/constvars"
+	"konsulin-service/internal/pkg/exceptions"
+	"konsulin-service/internal/pkg/utils"
+	"net/http"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+type WebhookController struct {
+	Log       *zap.Logger
+	Usecase   webhook.Usecase
+	Limiter   *ratelimiter.HookRateLimiter
+	AppConfig *config.InternalConfig
+}
+
+var (
+	webhookControllerInstance *WebhookController
+	onceWebhookController     sync.Once
+)
+
+func NewWebhookController(logger *zap.Logger, uc webhook.Usecase, limiter *ratelimiter.HookRateLimiter, cfg *config.InternalConfig) *WebhookController {
+	onceWebhookController.Do(func() {
+		webhookControllerInstance = &WebhookController{Log: logger, Usecase: uc, Limiter: limiter, AppConfig: cfg}
+	})
+	return webhookControllerInstance
+}
+
+// HandleEnqueueWebHook processes POST /api/v1/hook/{service_name}
+func (ctrl *WebhookController) HandleEnqueueWebHook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		utils.BuildErrorResponse(ctrl.Log, w, exceptions.BuildNewCustomError(nil, constvars.StatusMethodNotAllowed, "Only POST is allowed", "WEBHOOK_METHOD_NOT_ALLOWED"))
+		return
+	}
+
+	// Enforce Content-Type: application/json
+	if !strings.HasPrefix(r.Header.Get(constvars.HeaderContentType), constvars.MIMEApplicationJSON) {
+		utils.BuildErrorResponse(ctrl.Log, w, exceptions.BuildNewCustomError(nil, constvars.StatusUnsupportedMediaType, "Content-Type must be application/json", "WEBHOOK_UNSUPPORTED_MEDIA_TYPE"))
+		return
+	}
+
+	// Extract service_name from URL path (simple split, route attaches this under /hook/{service})
+	// Expecting router to mount as /{prefix}/{version}/hook/{service}
+	parts := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	serviceName := ""
+	if len(parts) >= 4 {
+		serviceName = parts[len(parts)-1]
+	}
+
+	// Validate serviceName: alphanumeric only; max len 256
+	if len(serviceName) == 0 || len(serviceName) > 256 {
+		utils.BuildErrorResponse(ctrl.Log, w, exceptions.ErrClientCustomMessage(exceptions.BuildNewCustomError(nil, constvars.StatusBadRequest, "Invalid service name", "WEBHOOK_INVALID_SERVICE_NAME")))
+		return
+	}
+	if ok, _ := regexp.MatchString(`^[A-Za-z0-9]+$`, serviceName); !ok {
+		utils.BuildErrorResponse(ctrl.Log, w, exceptions.ErrClientCustomMessage(exceptions.BuildNewCustomError(nil, constvars.StatusBadRequest, "Invalid service name", "WEBHOOK_INVALID_SERVICE_NAME")))
+		return
+	}
+
+	// Read raw JSON body
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		utils.BuildErrorResponse(ctrl.Log, w, exceptions.ErrReadBody(err))
+		return
+	}
+	defer r.Body.Close()
+
+	// Basic JSON check
+	var tmp map[string]interface{}
+	if err := json.Unmarshal(raw, &tmp); err != nil {
+		utils.BuildErrorResponse(ctrl.Log, w, exceptions.ErrCannotParseJSON(err))
+		return
+	}
+
+	// Rate limit evaluation before enqueue
+	eval, evalErr := ctrl.Limiter.Evaluate(r.Context(), &ratelimiter.EvaluateInput{ServiceName: serviceName, NowUTC: time.Now().UTC()})
+	if evalErr != nil {
+		utils.BuildErrorResponse(ctrl.Log, w, evalErr)
+		return
+	}
+	if !eval.Allowed {
+		retryAfter := eval.RetryAfterSecs
+		if retryAfter < 0 {
+			retryAfter = 0
+		}
+		w.Header().Set(constvars.HeaderRetryAfter, fmt.Sprintf("%d", retryAfter))
+		utils.BuildErrorResponse(ctrl.Log, w, exceptions.BuildNewCustomError(nil, constvars.StatusTooManyRequests, "Too many requests", "WEBHOOK_RATE_LIMITED"))
+		return
+	}
+
+	// Attach forwarded JWT header (if any) into context for usecase auth evaluation
+	fwd := r.Header.Get(webhook.JWTForwardedFromPaymentServiceHeader)
+	ctx := context.WithValue(r.Context(), webhook.JWTForwardedFromPaymentServiceHeader, fwd)
+
+	_, err = ctrl.Usecase.Enqueue(ctx, &webhook.EnqueueInput{
+		ServiceName: serviceName,
+		Method:      constvars.MethodPost,
+		RawJSON:     raw,
+	})
+	if err != nil {
+		// If 429 expected, return with Retry-After set by caller requirement later in router or here we can set minimal
+		// Prefer standard error handling
+		utils.BuildErrorResponse(ctrl.Log, w, err)
+		return
+	}
+
+	w.Header().Set(constvars.HeaderContentType, constvars.MIMEApplicationJSON)
+	w.WriteHeader(constvars.StatusAccepted)
+	w.Write([]byte(`{"success":true}`))
+}

--- a/internal/app/delivery/http/routers/router.go
+++ b/internal/app/delivery/http/routers/router.go
@@ -22,6 +22,7 @@ func SetupRoutes(
 	middlewares *middlewares.Middlewares,
 	authController *controllers.AuthController,
 	paymentController *controllers.PaymentController,
+	webhookController *controllers.WebhookController,
 ) {
 	corsOptions := cors.Options{
 		AllowOriginFunc: func(r *http.Request, origin string) bool {
@@ -68,6 +69,7 @@ func SetupRoutes(
 			})
 
 			attachPaymentRouter(r, middlewares, paymentController)
+			attachWebhookRouter(r, middlewares, webhookController)
 		})
 	})
 

--- a/internal/app/delivery/http/routers/webhook_router.go
+++ b/internal/app/delivery/http/routers/webhook_router.go
@@ -1,0 +1,15 @@
+package routers
+
+import (
+	"konsulin-service/internal/app/delivery/http/controllers"
+	"konsulin-service/internal/app/delivery/http/middlewares"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func attachWebhookRouter(router chi.Router, middlewares *middlewares.Middlewares, ctrl *controllers.WebhookController) {
+	// POST /hook/{service}
+	router.Post("/hook/{service}", ctrl.HandleEnqueueWebHook)
+}
+
+

--- a/internal/app/services/core/webhook/auth_helper.go
+++ b/internal/app/services/core/webhook/auth_helper.go
@@ -1,0 +1,107 @@
+package webhook
+
+import (
+	"context"
+	"konsulin-service/internal/app/services/shared/jwtmanager"
+	"konsulin-service/internal/pkg/constvars"
+	"konsulin-service/internal/pkg/exceptions"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+// ExtractAuthContextOutput holds requester identity derived from context.
+type ExtractAuthContextOutput struct {
+	// IsAPIKey indicates the request used superadmin API key auth.
+	IsAPIKey bool
+	// UID is the requester user id (or "anonymous" when absent per middleware behavior).
+	UID string
+	// Roles includes roles assigned by session or API key middleware.
+	Roles []string
+	// IsSuperadmin is true if roles include superadmin or IsAPIKey is true.
+	IsSuperadmin bool
+}
+
+// ExtractAuthContext reads values set by APIKeyAuth and SessionOptional middlewares.
+// It does not perform any I/O and is safe to call in controllers/handlers.
+func ExtractAuthContext(ctx context.Context) *ExtractAuthContextOutput {
+	out := &ExtractAuthContextOutput{
+		UID:   "",
+		Roles: []string{},
+	}
+
+	if v := ctx.Value("api_key_auth"); v != nil {
+		if b, ok := v.(bool); ok {
+			out.IsAPIKey = b
+		}
+	}
+
+	if v := ctx.Value("uid"); v != nil {
+		if s, ok := v.(string); ok {
+			out.UID = s
+		}
+	}
+
+	if v := ctx.Value("roles"); v != nil {
+		if list, ok := v.([]string); ok {
+			out.Roles = list
+		} else if anyList, ok := v.([]interface{}); ok {
+			roles := make([]string, 0, len(anyList))
+			for _, it := range anyList {
+				if s, ok := it.(string); ok {
+					roles = append(roles, s)
+				}
+			}
+			out.Roles = roles
+		}
+	}
+
+	for _, r := range out.Roles {
+		if strings.EqualFold(r, constvars.KonsulinRoleSuperadmin) {
+			out.IsSuperadmin = true
+			break
+		}
+	}
+	if out.IsAPIKey {
+		out.IsSuperadmin = true
+	}
+
+	return out
+}
+
+// EvaluateWebhookAuth returns nil if authorized. It supports forwarded JWT header or falls back to API key/session.
+func EvaluateWebhookAuth(ctx context.Context, log *zap.Logger, jwtMgr *jwtmanager.JWTManager, forwardedJWT string) error {
+	// Forwarded JWT path
+	if strings.TrimSpace(forwardedJWT) != "" {
+		out, err := jwtMgr.VerifyToken(ctx, &jwtmanager.VerifyTokenInput{Token: forwardedJWT})
+		requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)
+		if err != nil || out == nil || !out.Valid {
+			if log != nil {
+				log.Info("webhook auth: forwarded JWT invalid",
+					zap.String(constvars.LoggingRequestIDKey, requestID),
+					zap.Error(err),
+				)
+			}
+			return exceptions.BuildNewCustomError(nil, constvars.StatusUnauthorized, "Not authorized", "UNAUTHORIZED_WEBHOOK_CALLER")
+		}
+		if log != nil {
+			log.Info("webhook auth: forwarded JWT valid",
+				zap.String(constvars.LoggingRequestIDKey, requestID),
+			)
+		}
+		return nil
+	}
+
+	// Fallback to API key / session rules
+	info := ExtractAuthContext(ctx)
+	if info == nil {
+		return exceptions.BuildNewCustomError(nil, constvars.StatusUnauthorized, "Not authorized", "UNAUTHORIZED_WEBHOOK_CALLER")
+	}
+	if info.IsAPIKey || info.IsSuperadmin {
+		return nil
+	}
+	if info.UID != "" && !strings.EqualFold(info.UID, "anonymous") {
+		return nil
+	}
+	return exceptions.BuildNewCustomError(nil, constvars.StatusUnauthorized, "Not authorized", "UNAUTHORIZED_WEBHOOK_CALLER")
+}

--- a/internal/app/services/core/webhook/webhook_usecase_impl.go
+++ b/internal/app/services/core/webhook/webhook_usecase_impl.go
@@ -1,0 +1,88 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"konsulin-service/internal/app/config"
+	"konsulin-service/internal/app/services/shared/jwtmanager"
+	"konsulin-service/internal/app/services/shared/webhookqueue"
+	"konsulin-service/internal/pkg/constvars"
+	"konsulin-service/internal/pkg/exceptions"
+
+	"github.com/google/uuid"
+
+	"go.uber.org/zap"
+)
+
+// Usecase exposes operations for webhook service integration.
+type Usecase interface {
+	// Enqueue stores the incoming request in the durable queue after validation and rate limiting.
+	Enqueue(ctx context.Context, in *EnqueueInput) (*EnqueueOutput, error)
+}
+
+type usecase struct {
+	log        *zap.Logger
+	cfg        *config.InternalConfig
+	queue      *webhookqueue.Service
+	jwtManager *jwtmanager.JWTManager
+}
+
+// NewUsecase creates a new webhook usecase instance.
+func NewUsecase(log *zap.Logger, cfg *config.InternalConfig, queue *webhookqueue.Service, jwtMgr *jwtmanager.JWTManager) Usecase {
+	return &usecase{log: log, cfg: cfg, queue: queue, jwtManager: jwtMgr}
+}
+
+// EnqueueInput captures request details for enqueueing.
+type EnqueueInput struct {
+	ServiceName string
+	Method      string
+	RawJSON     json.RawMessage
+}
+
+// EnqueueOutput is empty for now; reserved for future metadata.
+type EnqueueOutput struct{}
+
+// JWTForwardedFromPaymentServiceHeader is a special header key that will be checked to
+// ensure the request comes from trusted payment service.
+const JWTForwardedFromPaymentServiceHeader = "X-Forwarded-From-Payment-Service"
+
+// Enqueue validates, rate-limits, and enqueues the message.
+func (u *usecase) Enqueue(ctx context.Context, in *EnqueueInput) (*EnqueueOutput, error) {
+	requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)
+	u.log.Info("webhook.usecase.Enqueue called",
+		zap.String(constvars.LoggingRequestIDKey, requestID),
+		zap.String("service_name", in.ServiceName),
+		zap.String("method", in.Method),
+	)
+
+	// Auth gate: support forwarded JWT header from payment service
+	forwarded := ""
+	if v := ctx.Value(JWTForwardedFromPaymentServiceHeader); v != nil {
+		if s, ok := v.(string); ok {
+			forwarded = s
+		}
+	}
+	if err := EvaluateWebhookAuth(ctx, u.log, u.jwtManager, forwarded); err != nil {
+		return nil, err
+	}
+
+	// Only POST allowed per requirement
+	if in.Method != constvars.MethodPost {
+		return nil, exceptions.ErrClientCustomMessage(exceptions.BuildNewCustomError(nil, constvars.StatusMethodNotAllowed, "Only POST is allowed", "WEBHOOK_METHOD_NOT_ALLOWED"))
+	}
+
+	// Enqueue durable message
+	msg := webhookqueue.WebhookQueueMessage{
+		ID:          uuid.NewString(),
+		Method:      in.Method,
+		ServiceName: in.ServiceName,
+		Body:        in.RawJSON,
+		FailedCount: 0,
+	}
+	_, err := u.queue.Enqueue(ctx, &webhookqueue.EnqueueToWebhookServiceQueueInput{Message: msg})
+	if err != nil {
+		return nil, err
+	}
+
+	return &EnqueueOutput{}, nil
+}

--- a/internal/app/services/core/webhook/worker.go
+++ b/internal/app/services/core/webhook/worker.go
@@ -1,0 +1,260 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"konsulin-service/internal/app/config"
+	"konsulin-service/internal/app/contracts"
+	"konsulin-service/internal/app/services/shared/jwtmanager"
+	"konsulin-service/internal/app/services/shared/webhookqueue"
+	"konsulin-service/internal/pkg/constvars"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// Worker periodically forwards queued webhook messages with at-least-once semantics.
+type Worker struct {
+	log        *zap.Logger
+	cfg        *config.InternalConfig
+	locker     contracts.LockerService
+	queue      *webhookqueue.Service
+	jwtManager *jwtmanager.JWTManager
+	client     *http.Client
+	stop       chan struct{}
+}
+
+// NewWorker creates a new worker instance.
+func NewWorker(log *zap.Logger, cfg *config.InternalConfig, lockerSvc contracts.LockerService, queue *webhookqueue.Service, jwtMgr *jwtmanager.JWTManager) *Worker {
+	timeout := time.Duration(cfg.Webhook.HTTPTimeoutInSeconds) * time.Second
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+	return &Worker{
+		log:        log,
+		cfg:        cfg,
+		locker:     lockerSvc,
+		queue:      queue,
+		jwtManager: jwtMgr,
+		client:     &http.Client{Timeout: timeout},
+		stop:       make(chan struct{}),
+	}
+}
+
+// Start begins the ticker loop. It returns a stop function to halt execution.
+func (w *Worker) Start(ctx context.Context) (stop func()) {
+	ticker := time.NewTicker(time.Minute)
+	stopped := make(chan struct{})
+
+	fmt.Println("Webhook worker started")
+
+	go func() {
+		defer close(stopped)
+		for {
+			select {
+			case <-ctx.Done():
+				ticker.Stop()
+				return
+			case <-w.stop:
+				ticker.Stop()
+				return
+			case now := <-ticker.C:
+				w.runOnce(ctx, now)
+			}
+		}
+	}()
+
+	return func() {
+		close(w.stop)
+	}
+}
+
+func (w *Worker) runOnce(ctx context.Context, now time.Time) {
+	w.log.Info("webhook.worker.runOnce tick",
+		zap.Time("now", now))
+
+	// Acquire best-effort distributed lock
+	nextMinute := now.Truncate(time.Minute).Add(time.Minute)
+	ttl := time.Until(nextMinute) - 1*time.Second
+	if ttl < 1*time.Second {
+		ttl = 1 * time.Second
+	}
+	acquired, lockVal, err := w.locker.TryLock(ctx, "webhook:worker:lock", ttl)
+	if err != nil {
+		w.log.Info("worker lock attempt failed",
+			zap.Error(err))
+		return
+	}
+	if !acquired {
+		w.log.Warn("worker lock not acquired; another instance is running")
+		return
+	}
+
+	w.log.Info("worker lock acquired")
+	defer func() {
+		if err := w.locker.Unlock(ctx, "webhook:worker:lock", lockVal); err != nil {
+			w.log.Error("worker unlock failed", zap.Error(err))
+		}
+	}()
+
+	max := w.cfg.Webhook.MaxQueue
+	if max <= 0 {
+		max = 1
+	}
+	out, err := w.queue.FetchN(ctx, &webhookqueue.FetchNInput{Max: max})
+	if err != nil {
+		w.log.Info("queue.FetchN error", zap.Error(err))
+		return
+	}
+
+	w.log.Info("queue.FetchN success", zap.Int("fetched_count", len(out.Items)))
+
+	for _, item := range out.Items {
+		w.processItem(ctx, item)
+	}
+}
+
+func (w *Worker) processItem(ctx context.Context, item webhookqueue.QueuedItem) {
+	msg := item.Message
+	// Build request
+	url := fmt.Sprintf("%s/%s", strings.TrimRight(w.cfg.Webhook.URL, "/"), msg.ServiceName)
+	req, err := http.NewRequestWithContext(ctx, msg.Method, url, bytes.NewReader(msg.Body))
+	if err != nil {
+		w.log.Info("build http request failed",
+			zap.String("service_name", msg.ServiceName),
+			zap.String("method", msg.Method),
+			zap.Error(err))
+		w.requeueOnError(ctx, item, msg, err, true)
+		return
+	}
+	req.Header.Set(constvars.HeaderContentType, constvars.MIMEApplicationJSON)
+
+	tokenOut, err := w.jwtManager.CreateToken(ctx, &jwtmanager.CreateTokenInput{Subject: msg.ServiceName})
+	if err != nil {
+		w.log.Info("jwt create token failed",
+			zap.String("service_name", msg.ServiceName),
+			zap.Error(err))
+		w.requeueOnError(ctx, item, msg, err, true)
+		return
+	}
+	req.Header.Set(constvars.HeaderAuthorization, "Bearer "+tokenOut.Token)
+
+	w.log.Info("forwarding webhook request",
+		zap.String("service_name", msg.ServiceName),
+		zap.String("message_id", msg.ID),
+		zap.String("method", msg.Method),
+		zap.String("url", url),
+		zap.Int("failed_count", msg.FailedCount))
+
+	resp, err := w.client.Do(req)
+	if err != nil {
+		w.log.Info("http request failed",
+			zap.String("service_name", msg.ServiceName),
+			zap.Error(err))
+		w.requeueOnError(ctx, item, msg, err, true)
+		return
+	}
+	defer resp.Body.Close()
+	_, _ = io.ReadAll(resp.Body) // drain for connection reuse
+
+	w.log.Info("webhook response received",
+		zap.String("service_name", msg.ServiceName),
+		zap.String("message_id", msg.ID),
+		zap.Int("status_code", resp.StatusCode))
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		// success: ack and drop
+		_, ackErr := w.queue.AckMessage(ctx, &webhookqueue.AckMessageInput{DeliveryTag: item.DeliveryTag})
+		if ackErr != nil {
+			w.log.Info("ack failed after success",
+				zap.String("service_name", msg.ServiceName),
+				zap.String("message_id", msg.ID),
+				zap.Error(ackErr))
+		}
+		w.log.Info("message processed successfully; removed from queue",
+			zap.String("service_name", msg.ServiceName),
+			zap.String("message_id", msg.ID))
+	case http.StatusUnauthorized, http.StatusForbidden:
+		// requeue without increment
+		if _, err := w.queue.Reenqueue(ctx, &webhookqueue.ReenqueueInput{Message: msg}); err != nil {
+			w.log.Info("reenqueue failed (401/403)",
+				zap.String("service_name", msg.ServiceName),
+				zap.String("message_id", msg.ID),
+				zap.Int("http_status", resp.StatusCode),
+				zap.Error(err))
+			return
+		}
+		_, _ = w.queue.AckMessage(ctx, &webhookqueue.AckMessageInput{DeliveryTag: item.DeliveryTag})
+		w.log.Warn("received 401/403; message returned to tail without incrementing failed count",
+			zap.String("service_name", msg.ServiceName),
+			zap.String("message_id", msg.ID),
+			zap.Int("failed_count", msg.FailedCount))
+	default:
+		// increment and requeue or DLQ
+		msg.FailedCount++
+		if msg.FailedCount >= w.cfg.Webhook.ThrottleRetry {
+			if _, err := w.queue.EnqueueToDeadQueue(ctx, &webhookqueue.EnqueueToDLQInput{Message: msg}); err != nil {
+				w.log.Info("enqueue to DLQ failed",
+					zap.String("service_name", msg.ServiceName),
+					zap.String("message_id", msg.ID),
+					zap.Error(err))
+				return
+			}
+			_, _ = w.queue.AckMessage(ctx, &webhookqueue.AckMessageInput{DeliveryTag: item.DeliveryTag})
+			w.log.Info("moved message to DLQ",
+				zap.String("service_name", msg.ServiceName),
+				zap.String("message_id", msg.ID),
+				zap.Int("failed_count", msg.FailedCount))
+			return
+		}
+		if _, err := w.queue.Reenqueue(ctx, &webhookqueue.ReenqueueInput{Message: msg}); err != nil {
+			w.log.Info("reenqueue failed (error status)",
+				zap.String("service_name", msg.ServiceName),
+				zap.String("message_id", msg.ID),
+				zap.Error(err))
+			return
+		}
+		_, _ = w.queue.AckMessage(ctx, &webhookqueue.AckMessageInput{DeliveryTag: item.DeliveryTag})
+		w.log.Info("retryable failure; incremented failedCount and requeued",
+			zap.String("service_name", msg.ServiceName),
+			zap.String("message_id", msg.ID),
+			zap.Int("failed_count", msg.FailedCount))
+	}
+}
+
+func (w *Worker) requeueOnError(ctx context.Context, item webhookqueue.QueuedItem, msg webhookqueue.WebhookQueueMessage, err error, increment bool) {
+	if increment {
+		msg.FailedCount++
+	}
+	if msg.FailedCount >= w.cfg.Webhook.ThrottleRetry {
+		if _, e := w.queue.EnqueueToDeadQueue(ctx, &webhookqueue.EnqueueToDLQInput{Message: msg}); e != nil {
+			w.log.Info("enqueue to DLQ failed (network)",
+				zap.String("service_name", msg.ServiceName),
+				zap.String("message_id", msg.ID),
+				zap.Error(e))
+			return
+		}
+		_, _ = w.queue.AckMessage(ctx, &webhookqueue.AckMessageInput{DeliveryTag: item.DeliveryTag})
+		w.log.Info("network/error; moved message to DLQ",
+			zap.String("service_name", msg.ServiceName),
+			zap.String("message_id", msg.ID),
+			zap.Int("failed_count", msg.FailedCount))
+		return
+	}
+	if _, e := w.queue.Reenqueue(ctx, &webhookqueue.ReenqueueInput{Message: msg}); e != nil {
+		w.log.Info("reenqueue failed (network)",
+			zap.String("service_name", msg.ServiceName),
+			zap.String("message_id", msg.ID),
+			zap.Error(e))
+		return
+	}
+	_, _ = w.queue.AckMessage(ctx, &webhookqueue.AckMessageInput{DeliveryTag: item.DeliveryTag})
+	w.log.Info("network/error; requeued message to tail",
+		zap.String("service_name", msg.ServiceName),
+		zap.String("message_id", msg.ID),
+		zap.Int("failed_count", msg.FailedCount))
+}

--- a/internal/app/services/shared/jwtmanager/jwt_manager.go
+++ b/internal/app/services/shared/jwtmanager/jwt_manager.go
@@ -1,0 +1,244 @@
+package jwtmanager
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"konsulin-service/internal/app/config"
+	"konsulin-service/internal/pkg/constvars"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"go.uber.org/zap"
+)
+
+const (
+	algES256 = "ES256"
+	algRS256 = "RS256"
+)
+
+// JWTManager handles JWT creation and verification for webhook calls.
+type JWTManager struct {
+	log     *zap.Logger
+	alg     string
+	ttl     time.Duration
+	ecPriv  *ecdsa.PrivateKey
+	rsaPriv *rsa.PrivateKey
+}
+
+// CreateTokenInput defines input parameters for token creation.
+type CreateTokenInput struct {
+	Subject string
+	// Payload is reserved for future custom claims. Currently unused by design.
+	Payload map[string]interface{}
+}
+
+// CreateTokenOutput contains the signed token string.
+type CreateTokenOutput struct {
+	Token string
+}
+
+// VerifyTokenInput defines parameters for token verification.
+type VerifyTokenInput struct {
+	Token string
+}
+
+// VerifyTokenOutput contains verification result and decoded parts.
+type VerifyTokenOutput struct {
+	Valid  bool
+	Header map[string]interface{}
+	Claims map[string]interface{}
+}
+
+// NewJWTManager constructs a JWTManager using InternalConfig.Webhook and a logger.
+// - Algorithm: ES256 (default) or RS256 via InternalConfig.Webhook.JWTAlg
+// - Private key: PEM string from InternalConfig.Webhook.JWTHookKey
+// - TTL: fixed 5 minutes per requirements
+func NewJWTManager(cfg *config.InternalConfig, log *zap.Logger) (*JWTManager, error) {
+	alg := strings.ToUpper(strings.TrimSpace(cfg.Webhook.JWTAlg))
+	if alg == "" {
+		alg = algES256
+	}
+
+	pemKey := strings.TrimSpace(cfg.Webhook.JWTHookKey)
+	if pemKey == "" {
+		return nil, fmt.Errorf("JWT_HOOK_KEY is empty")
+	}
+
+	block, _ := pem.Decode([]byte(pemKey))
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode PEM for JWT_HOOK_KEY")
+	}
+
+	jm := &JWTManager{
+		log: log,
+		alg: alg,
+		ttl: 5 * time.Minute, // fixed by requirement
+	}
+
+	switch alg {
+	case algES256:
+		// Expect EC private key
+		ecKey, err := parseECPrivateKey(block)
+		if err != nil {
+			return nil, err
+		}
+		jm.ecPriv = ecKey
+	case algRS256:
+		rsaKey, err := parseRSAPrivateKey(block)
+		if err != nil {
+			return nil, err
+		}
+		jm.rsaPriv = rsaKey
+	default:
+		return nil, fmt.Errorf("unsupported JWT algorithm: %s", alg)
+	}
+
+	return jm, nil
+}
+
+// CreateToken generates a signed JWT with standard claims and the given subject.
+// It sets iat, nbf to now and exp to now + 5 minutes.
+func (j *JWTManager) CreateToken(ctx context.Context, in *CreateTokenInput) (*CreateTokenOutput, error) {
+	requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)
+	j.log.Info("JWTManager.CreateToken called", zap.String(constvars.LoggingRequestIDKey, requestID))
+
+	if in == nil || strings.TrimSpace(in.Subject) == "" {
+		return nil, fmt.Errorf("subject is required")
+	}
+
+	now := time.Now().UTC()
+	claims := jwt.MapClaims{
+		"sub": in.Subject,
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+		"exp": now.Add(j.ttl).Unix(),
+	}
+
+	var token *jwt.Token
+	switch j.alg {
+	case algES256:
+		token = jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+		signed, err := token.SignedString(j.ecPriv)
+		if err != nil {
+			return nil, err
+		}
+		return &CreateTokenOutput{Token: signed}, nil
+	case algRS256:
+		token = jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+		signed, err := token.SignedString(j.rsaPriv)
+		if err != nil {
+			return nil, err
+		}
+		return &CreateTokenOutput{Token: signed}, nil
+	default:
+		return nil, fmt.Errorf("unsupported algorithm: %s", j.alg)
+	}
+}
+
+// VerifyToken validates a token's signature and expiry and returns decoded header and claims.
+func (j *JWTManager) VerifyToken(ctx context.Context, in *VerifyTokenInput) (*VerifyTokenOutput, error) {
+	requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)
+	j.log.Info("JWTManager.VerifyToken called", zap.String(constvars.LoggingRequestIDKey, requestID))
+
+	if in == nil || strings.TrimSpace(in.Token) == "" {
+		return &VerifyTokenOutput{Valid: false}, fmt.Errorf("token is required")
+	}
+
+	keyFunc := func(t *jwt.Token) (interface{}, error) {
+		// enforce expected alg
+		if t.Method.Alg() != j.alg {
+			return nil, fmt.Errorf("unexpected signing method: %s", t.Header["alg"])
+		}
+		switch j.alg {
+		case algES256:
+			if j.ecPriv == nil {
+				return nil, errors.New("ec private key not loaded")
+			}
+			pub := j.ecPriv.Public().(*ecdsa.PublicKey)
+			return pub, nil
+		case algRS256:
+			if j.rsaPriv == nil {
+				return nil, errors.New("rsa private key not loaded")
+			}
+			pub := j.rsaPriv.Public().(*rsa.PublicKey)
+			return pub, nil
+		default:
+			return nil, fmt.Errorf("unsupported algorithm: %s", j.alg)
+		}
+	}
+
+	parsed, err := jwt.Parse(in.Token, keyFunc)
+	if err != nil {
+		return &VerifyTokenOutput{Valid: false}, nil
+	}
+
+	// Extract header
+	header := make(map[string]interface{}, len(parsed.Header))
+	for k, v := range parsed.Header {
+		header[k] = v
+	}
+
+	// Extract claims
+	claims := make(map[string]interface{})
+	if c, ok := parsed.Claims.(jwt.MapClaims); ok {
+		for k, v := range c {
+			claims[k] = v
+		}
+	}
+
+	// Ensure expiry/nbf are valid
+	if !parsed.Valid {
+		return &VerifyTokenOutput{Valid: false, Header: header, Claims: claims}, nil
+	}
+
+	return &VerifyTokenOutput{Valid: true, Header: header, Claims: claims}, nil
+}
+
+func parseECPrivateKey(block *pem.Block) (*ecdsa.PrivateKey, error) {
+	if block.Type == "EC PRIVATE KEY" {
+		key, err := x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse EC private key: %w", err)
+		}
+		return key, nil
+	}
+	if block.Type == "PRIVATE KEY" { // PKCS#8 which may wrap EC
+		keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKCS8 private key: %w", err)
+		}
+		if ec, ok := keyAny.(*ecdsa.PrivateKey); ok {
+			return ec, nil
+		}
+		return nil, fmt.Errorf("PKCS8 key is not ECDSA")
+	}
+	return nil, fmt.Errorf("unsupported EC PEM type: %s", block.Type)
+}
+
+func parseRSAPrivateKey(block *pem.Block) (*rsa.PrivateKey, error) {
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKCS1 private key: %w", err)
+		}
+		return key, nil
+	case "PRIVATE KEY": // PKCS#8
+		keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKCS8 private key: %w", err)
+		}
+		if rsaKey, ok := keyAny.(*rsa.PrivateKey); ok {
+			return rsaKey, nil
+		}
+		return nil, fmt.Errorf("PKCS8 key is not RSA")
+	default:
+		return nil, fmt.Errorf("unsupported RSA PEM type: %s", block.Type)
+	}
+}

--- a/internal/app/services/shared/ratelimiter/hook_rate_limiter.go
+++ b/internal/app/services/shared/ratelimiter/hook_rate_limiter.go
@@ -1,0 +1,126 @@
+package ratelimiter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"konsulin-service/internal/app/config"
+	"konsulin-service/internal/app/contracts"
+	"konsulin-service/internal/pkg/constvars"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// HookRateLimiter enforces 60s window and monthly quotas by service name.
+// It operates only when serviceName is listed in the blacklist CSV controllable from env.
+type HookRateLimiter struct {
+	redis           contracts.RedisRepository
+	log             *zap.Logger
+	rateLimit       int
+	monthlyQuota    int
+	limitedServices map[string]struct{}
+}
+
+// NewHookRateLimiter constructs the limiter using InternalConfig.Webhook.
+func NewHookRateLimiter(redis contracts.RedisRepository, log *zap.Logger, cfg *config.InternalConfig) *HookRateLimiter {
+	limited := make(map[string]struct{})
+	if csv := strings.TrimSpace(cfg.Webhook.RateLimitedServices); csv != "" {
+		for _, s := range strings.Split(csv, ",") {
+			name := strings.TrimSpace(s)
+			if name != "" {
+				limited[strings.ToLower(name)] = struct{}{}
+			}
+		}
+	}
+	return &HookRateLimiter{
+		redis:           redis,
+		log:             log,
+		rateLimit:       cfg.Webhook.RateLimit,
+		monthlyQuota:    cfg.Webhook.MonthlyQuota,
+		limitedServices: limited,
+	}
+}
+
+// EvaluateInput to check rate limits for a service.
+type EvaluateInput struct {
+	ServiceName string
+	NowUTC      time.Time
+}
+
+// EvaluateOutput contains allow flag and retry-after seconds and reason.
+type EvaluateOutput struct {
+	Allowed          bool
+	RetryAfterSecs   int
+	LimitedByMonthly bool
+}
+
+// Evaluate returns allowance; if not allowed, it returns the Retry-After seconds.
+// Keys are based on service name only per requirement.
+func (l *HookRateLimiter) Evaluate(ctx context.Context, in *EvaluateInput) (*EvaluateOutput, error) {
+	requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)
+	l.log.Info("HookRateLimiter.Evaluate called",
+		zap.String(constvars.LoggingRequestIDKey, requestID),
+		zap.String("service_name", in.ServiceName))
+
+	service := strings.ToLower(strings.TrimSpace(in.ServiceName))
+	if service == "" {
+		return &EvaluateOutput{Allowed: false, RetryAfterSecs: 60}, nil
+	}
+
+	if _, ok := l.limitedServices[service]; !ok {
+		return &EvaluateOutput{Allowed: true}, nil
+	}
+
+	// Monthly quota key: HOOK:QUOTA:<YYYYMM>:<service>
+	monthKey := fmt.Sprintf("HOOK:QUOTA:%s:%s", in.NowUTC.Format("200601"), service)
+	// TTL until the end of month (UTC)
+	firstOfNextMonth := time.Date(in.NowUTC.Year(), in.NowUTC.Month()+1, 1, 0, 0, 0, 0, time.UTC)
+	ttlMonthly := time.Until(firstOfNextMonth)
+
+	// Read current monthly count
+	currentMonthlyStr, _ := l.redis.Get(ctx, monthKey)
+	var currentMonthly int
+	if currentMonthlyStr != "" {
+		_ = json.Unmarshal([]byte(currentMonthlyStr), &currentMonthly)
+	}
+
+	if currentMonthly >= l.monthlyQuota && l.monthlyQuota > 0 {
+		// Over monthly quota => Retry-After until next month boundary
+		return &EvaluateOutput{Allowed: false, RetryAfterSecs: int(ttlMonthly.Seconds()) + 1, LimitedByMonthly: true}, nil
+	}
+
+	// 60s window key: HOOK:LIMIT:<YYYYMMDDHHMM>:<service>
+	minuteKey := fmt.Sprintf("HOOK:LIMIT:%s:%s", in.NowUTC.Format("200601021504"), service)
+	// TTL until end of the current minute window
+	nextMinute := in.NowUTC.Truncate(time.Minute).Add(time.Minute)
+	ttlMinute := time.Until(nextMinute)
+
+	// Read current minute count
+	currentMinuteStr, _ := l.redis.Get(ctx, minuteKey)
+	var currentMinute int
+	if currentMinuteStr != "" {
+		_ = json.Unmarshal([]byte(currentMinuteStr), &currentMinute)
+	}
+
+	if currentMinute >= l.rateLimit && l.rateLimit > 0 {
+		// Over per-minute window => Retry-After until next minute
+		return &EvaluateOutput{Allowed: false, RetryAfterSecs: int(ttlMinute.Seconds()) + 1, LimitedByMonthly: false}, nil
+	}
+
+	// Increment counters with TTL set if first time
+	if currentMinute == 0 {
+		_ = l.redis.Set(ctx, minuteKey, 1, ttlMinute+time.Second)
+	} else {
+		_ = l.redis.Increment(ctx, minuteKey)
+	}
+
+	if currentMonthly == 0 {
+		_ = l.redis.Set(ctx, monthKey, 1, ttlMonthly+time.Minute)
+	} else {
+		_ = l.redis.Increment(ctx, monthKey)
+	}
+
+	return &EvaluateOutput{Allowed: true}, nil
+}

--- a/internal/app/services/shared/webhookqueue/webhook_queue_service.go
+++ b/internal/app/services/shared/webhookqueue/webhook_queue_service.go
@@ -1,0 +1,302 @@
+package webhookqueue
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"konsulin-service/internal/pkg/constvars"
+	"konsulin-service/internal/pkg/exceptions"
+	"sync"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+	"go.uber.org/zap"
+)
+
+const (
+	// Standard and DLQ names as requested.
+	StandardQueueName   = "standard_webhook_service_queue"
+	DeadLetterQueueName = "standard_webhook_service_dlq"
+)
+
+// WebhookQueueMessage represents the payload stored in RabbitMQ.
+type WebhookQueueMessage struct {
+	ID          string          `json:"id"`
+	Method      string          `json:"method"`
+	ServiceName string          `json:"service_name"`
+	Body        json.RawMessage `json:"body"`
+	FailedCount int             `json:"failed_count"`
+}
+
+// Service manages interactions with RabbitMQ queues for the webhook feature.
+type Service struct {
+	ch       *amqp.Channel
+	log      *zap.Logger
+	prefetch int
+	confirms chan amqp.Confirmation
+	mu       sync.Mutex
+}
+
+// NewService initializes the queue service, declares durable queues, enables confirms, and sets QoS.
+func NewService(conn *amqp.Connection, log *zap.Logger, prefetch int) (*Service, error) {
+	ch, err := conn.Channel()
+	if err != nil {
+		return nil, err
+	}
+
+	// Declare standard queue (durable)
+	_, err = ch.QueueDeclare(
+		StandardQueueName, // name
+		true,              // durable
+		false,             // autoDelete
+		false,             // exclusive
+		false,             // noWait
+		nil,               // args
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Declare dead-letter queue (durable)
+	_, err = ch.QueueDeclare(
+		DeadLetterQueueName,
+		true,
+		false,
+		false,
+		false,
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set QoS to limit unacked deliveries in-flight
+	if prefetch <= 0 {
+		prefetch = 1
+	}
+	if err := ch.Qos(prefetch, 0, false); err != nil {
+		return nil, err
+	}
+
+	// Enable publisher confirms for durability guarantees
+	if err := ch.Confirm(false); err != nil {
+		return nil, err
+	}
+
+	svc := &Service{
+		ch:       ch,
+		log:      log,
+		prefetch: prefetch,
+		confirms: ch.NotifyPublish(make(chan amqp.Confirmation, 1)),
+	}
+
+	return svc, nil
+}
+
+// EnqueueToWebhookServiceQueueInput defines input for enqueue operation.
+type EnqueueToWebhookServiceQueueInput struct {
+	Message WebhookQueueMessage
+}
+
+// EnqueueToWebhookServiceQueueOutput defines output for enqueue.
+type EnqueueToWebhookServiceQueueOutput struct{}
+
+// EnqueueToDLQInput defines input for DLQ enqueue operation.
+type EnqueueToDLQInput struct {
+	Message WebhookQueueMessage
+}
+
+// EnqueueToDLQOutput defines output for DLQ enqueue.
+type EnqueueToDLQOutput struct{}
+
+// ReenqueueInput defines input for reenqueueing a modified message back to the standard queue tail.
+type ReenqueueInput struct {
+	Message WebhookQueueMessage
+}
+
+// ReenqueueOutput defines output for reenqueue.
+type ReenqueueOutput struct{}
+
+// FetchNInput specifies the maximum number of messages to fetch.
+type FetchNInput struct {
+	Max int
+}
+
+// QueuedItem represents a fetched delivery and its decoded payload.
+type QueuedItem struct {
+	DeliveryTag uint64
+	Message     WebhookQueueMessage
+}
+
+// FetchNOutput returns up to N messages.
+type FetchNOutput struct {
+	Items []QueuedItem
+}
+
+// AckMessageInput acknowledges a message so it is removed from the queue.
+type AckMessageInput struct {
+	DeliveryTag uint64
+}
+
+// AckMessageOutput is empty.
+type AckMessageOutput struct{}
+
+// Enqueue publishes a message to the standard queue with persistence and waits for confirm.
+func (s *Service) Enqueue(ctx context.Context, in *EnqueueToWebhookServiceQueueInput) (*EnqueueToWebhookServiceQueueOutput, error) {
+	requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)
+	s.log.Info("WebhookQueue.Enqueue called", zap.String(constvars.LoggingRequestIDKey, requestID))
+
+	body, err := json.Marshal(in.Message)
+	if err != nil {
+		return nil, exceptions.ErrCannotMarshalJSON(err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	msg := amqp.Publishing{
+		ContentType:  constvars.MIMEApplicationJSON,
+		Body:         body,
+		DeliveryMode: amqp.Persistent,
+	}
+
+	if err := s.ch.PublishWithContext(ctx, "", StandardQueueName, false, false, msg); err != nil {
+		return nil, exceptions.ErrRabbitMQPublishMessage(err, StandardQueueName)
+	}
+
+	select {
+	case confirmed := <-s.confirms:
+		if !confirmed.Ack {
+			return nil, exceptions.ErrRabbitMQPublishMessage(fmt.Errorf("message not confirmed"), StandardQueueName)
+		}
+	case <-ctx.Done():
+		return nil, exceptions.ErrRabbitMQPublishMessage(ctx.Err(), StandardQueueName)
+	}
+	return &EnqueueToWebhookServiceQueueOutput{}, nil
+}
+
+// Reenqueue publishes the (possibly modified) message to the tail of the standard queue and confirms.
+func (s *Service) Reenqueue(ctx context.Context, in *ReenqueueInput) (*ReenqueueOutput, error) {
+	requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)
+	s.log.Info("WebhookQueue.Reenqueue called", zap.String(constvars.LoggingRequestIDKey, requestID))
+
+	body, err := json.Marshal(in.Message)
+	if err != nil {
+		return nil, exceptions.ErrCannotMarshalJSON(err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	msg := amqp.Publishing{
+		ContentType:  constvars.MIMEApplicationJSON,
+		Body:         body,
+		DeliveryMode: amqp.Persistent,
+	}
+
+	if err := s.ch.PublishWithContext(ctx, "", StandardQueueName, false, false, msg); err != nil {
+		return nil, exceptions.ErrRabbitMQPublishMessage(err, StandardQueueName)
+	}
+	select {
+	case confirmed := <-s.confirms:
+		if !confirmed.Ack {
+			return nil, exceptions.ErrRabbitMQPublishMessage(fmt.Errorf("message not confirmed"), StandardQueueName)
+		}
+	case <-ctx.Done():
+		return nil, exceptions.ErrRabbitMQPublishMessage(ctx.Err(), StandardQueueName)
+	}
+	return &ReenqueueOutput{}, nil
+}
+
+// EnqueueToDeadQueue publishes the message to DLQ and confirms.
+func (s *Service) EnqueueToDeadQueue(ctx context.Context, in *EnqueueToDLQInput) (*EnqueueToDLQOutput, error) {
+	requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)
+	s.log.Info("WebhookQueue.EnqueueToDeadQueue called", zap.String(constvars.LoggingRequestIDKey, requestID))
+
+	body, err := json.Marshal(in.Message)
+	if err != nil {
+		return nil, exceptions.ErrCannotMarshalJSON(err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	msg := amqp.Publishing{
+		ContentType:  constvars.MIMEApplicationJSON,
+		Body:         body,
+		DeliveryMode: amqp.Persistent,
+	}
+
+	if err := s.ch.PublishWithContext(ctx, "", DeadLetterQueueName, false, false, msg); err != nil {
+		return nil, exceptions.ErrRabbitMQPublishMessage(err, DeadLetterQueueName)
+	}
+	select {
+	case confirmed := <-s.confirms:
+		if !confirmed.Ack {
+			return nil, exceptions.ErrRabbitMQPublishMessage(fmt.Errorf("message not confirmed"), DeadLetterQueueName)
+		}
+	case <-ctx.Done():
+		return nil, exceptions.ErrRabbitMQPublishMessage(ctx.Err(), DeadLetterQueueName)
+	}
+	return &EnqueueToDLQOutput{}, nil
+}
+
+// FetchN retrieves up to N messages using basic.get without auto-ack.
+func (s *Service) FetchN(ctx context.Context, in *FetchNInput) (*FetchNOutput, error) {
+	requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)
+	s.log.Info("WebhookQueue.FetchN called", zap.String(constvars.LoggingRequestIDKey, requestID))
+
+	n := in.Max
+	if n <= 0 {
+		n = 1
+	}
+	items := make([]QueuedItem, 0, n)
+
+	for i := 0; i < n; i++ {
+		d, ok, err := s.ch.Get(StandardQueueName, false)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			break
+		}
+		var payload WebhookQueueMessage
+		if err := json.Unmarshal(d.Body, &payload); err != nil {
+			// If payload is invalid JSON, move to DLQ to avoid poison message loop
+			_ = d.Ack(false)
+			_ = s.publishRaw(ctx, DeadLetterQueueName, d.Body)
+			continue
+		}
+		items = append(items, QueuedItem{DeliveryTag: d.DeliveryTag, Message: payload})
+	}
+
+	return &FetchNOutput{Items: items}, nil
+}
+
+// AckMessage acknowledges a message by delivery tag.
+func (s *Service) AckMessage(ctx context.Context, in *AckMessageInput) (*AckMessageOutput, error) {
+	requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)
+	s.log.Info("WebhookQueue.AckMessage called", zap.String(constvars.LoggingRequestIDKey, requestID))
+	if err := s.ch.Ack(in.DeliveryTag, false); err != nil {
+		return nil, err
+	}
+	return &AckMessageOutput{}, nil
+}
+
+// publishRaw is a small helper to publish raw body to a queue (used for poison messages).
+func (s *Service) publishRaw(ctx context.Context, queue string, body []byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	msg := amqp.Publishing{ContentType: constvars.MIMEApplicationJSON, Body: body, DeliveryMode: amqp.Persistent}
+	if err := s.ch.PublishWithContext(ctx, "", queue, false, false, msg); err != nil {
+		return exceptions.ErrRabbitMQPublishMessage(err, queue)
+	}
+	select {
+	case confirmed := <-s.confirms:
+		if !confirmed.Ack {
+			return exceptions.ErrRabbitMQPublishMessage(fmt.Errorf("message not confirmed"), queue)
+		}
+	case <-ctx.Done():
+		return exceptions.ErrRabbitMQPublishMessage(ctx.Err(), queue)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

To open up a new endpoint that acts like a proxy between konsulin-api users and webhook service

## Purpose

To handle incoming request without overloading the webhook service by implementing request queue that will eventually be forwarded to webhook service with at [least once delivery](https://www.letanure.dev/blog/2025-06-12--at-least-once-vs-exactly-once) guaranteed

## Components

This feature will have several components that support the purpose of this feature. Below are the details of each of them.

### Rate Limiter
This component will enforce a rule which limit the amount of request can be made by a user for a certain service for a specific time window. This component is configurable through these environment values:

- `HOOK_RATE_LIMIT` (int)
Can be used to specify how many request can a user make for a given service for 60s time window. Set to negative value to disable.

- `HOOK_QUOTA` (int)
Can be used to limit how much a request can be made by a user for a certain service in any given calendar month. Set to negative value to disable.

- `HOOK_RATE_LIMITED_SERVICES` (string)
A comma separated string that contain name of services that must be protected by the rate limiter, such as a free service or a heavy / on demand service. Empty string means no service will be rate limited.

### JWT Manager
JWT manager will responsible to interact with JWT token, such as but not limited to create and to verify a given token. This component can be configured through these environment keys:

- `HOOK_JWT_ALG` (enum: RS256 | ES256)
Algorithm to be choose to generate the token signature

- `JWT_HOOK_KEY` (string)
The private key to sign the token. Example value in the .env file:

<pre>
JWT_HOOK_KEY='-----BEGIN EC PRIVATE KEY-----
example long private key goes here
-----END EC PRIVATE KEY-----'
</pre>

For Docker Compose, place the multiline PEM in a single-quoted env value as above.

### Queue
Queue is a datatype that implements FIFO ordering and utilized as a storage to save user requests before being forwarded to webhook service. The queue will be made `durable`, meaning the data will not be lost even during system restart. This is also the component that makes [least once delivery](https://www.letanure.dev/blog/2025-06-12--at-least-once-vs-exactly-once) guarantee possible. This feature will utilize two queues; `standard_webhook_service_queue` and `standard_webhook_service_dlq`.

The way each queue works is as follows: of any success incoming request will be saved to `standard_webhook_service_queue` . If when forwarded, some error hapen, the data will be put back at the tail of the `standard_webhook_service_queue` queue. However, if this keeps happening, after a number of retry it still returns error, the data will be moved to `standard_webhook_service_dlq` where it will be kept there until further decision.

### Background Worker

This is a special type of process that run on the background, meaning it wont serve users' request directly. The worker will execute once periodically and performing data forwarding to webhook service process. It is responsible to handle respons from webhook service, whether a success one, or a failed one. Worker will also responsible to handle logic related to retry, such as when should the message be put back into the `standard_webhook_service_queue` or moved to `standard_webhook_service_dlq`. 

The worker can be configured through these environment keys:
- `HOOK_HTTP_TIMEOUT` (int)
how long should the server wait for webhook service response before marking the request as timeout in seconds.

- `HOOK_MAX_QUEUE` (int)
control how much data being forwarded in any given time the worker runs.

- `HOOK_THROTTLE_RETRY` (int)
how much the request is allowed to be retried despide failure happen before when forwarding it to the webhook service.

- `HOOK_URL` (string)
will tell where should the request forwarder (the webhook service URI)

The background worker is safe to be deployed on more than 1 instance and won't duplicating the request by N fold thanks to the implemented best effort lock powered by redis that ensure at max 1 worker can perform the request forwaring in any given minute.

### Testing
Below are cases that already being tested on this feature:

- rate limiting a specific service, both the 60s window and monthly usage.
- purchasing service from payment service and ensure the request forwarded to the webhook service.
- ensuring data on the queues is persistent and durable
- Ensuring the worker executes at least once in 60s
- Ensuring the worker able to sent at max `HOOK_MAX_QUEUE` number of data per 60s
- ensure request coming from payment service protected using JWT token

### Question and answer

`Who and what are the indicators that affect retry policy?`
The only entitiy that should be responsible to be used in retry decision is the webhook service's response. I have placed a code part that decide what response considered success thus removing the data from queue, what response that indicates a retryable failure without consuming maximum retry quota, what response that indicates a retryable failure but consume maximum retry quota
