### PR TITLE
Fix/allow anonymous request and enchance rate limitting

### DIFF
--- a/internal/app/services/core/webhook/auth_helper.go
+++ b/internal/app/services/core/webhook/auth_helper.go
@@ -100,7 +100,12 @@ func EvaluateWebhookAuth(ctx context.Context, log *zap.Logger, jwtMgr *jwtmanage
 	if info.IsAPIKey || info.IsSuperadmin {
 		return nil
 	}
-	if info.UID != "" && !strings.EqualFold(info.UID, "anonymous") {
+	// Allow anonymous users as well (uid empty or "anonymous")
+	if info.UID == "" || strings.EqualFold(info.UID, "anonymous") {
+		return nil
+	}
+	// Any authenticated uid is allowed
+	if info.UID != "" {
 		return nil
 	}
 	return exceptions.BuildNewCustomError(nil, constvars.StatusUnauthorized, "Not authorized", "UNAUTHORIZED_WEBHOOK_CALLER")


### PR DESCRIPTION
## Summary

Allow anonymous session user to use webhook integration endpoint and enchance rate limit configuration

## Purpose

Allowing unauthenticated (guess) request to be processed by the wehbook endpoint handler. Also, make the rate limitter key saved not only per service basis, but also per service and per user basis. This will make a service usage can't be starved by one particular greedy user

## Testing

Now, making a request as a guest will be allowed and the request will eventually be processed by the server

<pre>
curl --request POST \
  --url http://localhost:8000/api/v1/hook/interpret \
  --header 'Content-Type: application/json' \
  --header 'User-Agent: insomnia/11.6.1' \
  --data '{
  "body": {
    "longbodyhere"
}'
</pre>

the log output
<pre>
{"level":"INFO","time":"2025/09/26 14:08:11","caller":"webhook/worker.go:114","msg":"queue.FetchN success","fetched_count":1}
{"level":"INFO","time":"2025/09/26 14:08:11","caller":"jwtmanager/jwt_manager.go:109","msg":"JWTManager.CreateToken called","request_id":""}
{"level":"INFO","time":"2025/09/26 14:08:11","caller":"webhook/worker.go:146","msg":"forwarding webhook request","service_name":"interpret","message_id":"16b693ce-0f8b-4c69-9211-02f759c70158","method":"POST","url":"https://flow.konsulin.care/webhook/staging/interpret","failed_count":0}
{"level":"INFO","time":"2025/09/26 14:08:13","caller":"webhook/worker.go:164","msg":"webhook response received","service_name":"interpret","message_id":"16b693ce-0f8b-4c69-9211-02f759c70158","status_code":200}
{"level":"INFO","time":"2025/09/26 14:08:13","caller":"webhookqueue/webhook_queue_service.go:278","msg":"WebhookQueue.AckMessage called","request_id":""}
{"level":"INFO","time":"2025/09/26 14:08:13","caller":"webhook/worker.go:178","msg":"message processed successfully; removed from queue","service_name":"interpret","message_id":"16b693ce-0f8b-4c69-9211-02f759c70158"}
</pre>