### PR TITLE
Feat/enforce a paid only service

### DIFF
--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -125,6 +125,7 @@ func loadInternalConfigWithEnv() *InternalConfig {
 			RateLimit:            utils.GetEnvInt("HOOK_RATE_LIMIT", 0),
 			MonthlyQuota:         utils.GetEnvInt("HOOK_QUOTA", 0),
 			RateLimitedServices:  utils.GetEnvString("HOOK_RATE_LIMITED_SERVICES", ""),
+			PaidOnlyServices:     utils.GetEnvString("HOOK_PAID_ONLY_SERVICES", ""),
 			MaxQueue:             utils.GetEnvInt("HOOK_MAX_QUEUE", 1),
 			ThrottleRetry:        utils.GetEnvInt("HOOK_THROTTLE_RETRY", 15),
 			URL:                  utils.GetEnvString("HOOK_URL", ""),

--- a/internal/app/config/internal.go
+++ b/internal/app/config/internal.go
@@ -108,6 +108,8 @@ type AppWebhook struct {
 	MonthlyQuota int `mapstructure:"monthly_quota"`
 	// RateLimitedServices is a CSV list of service names subject to rate limiting
 	RateLimitedServices string `mapstructure:"rate_limited_services"`
+	// PaidOnlyServices is a CSV list of service names that require a forwarded JWT from payment service
+	PaidOnlyServices string `mapstructure:"paid_only_services"`
 	// MaxQueue defines how many items the worker processes per tick
 	MaxQueue int `mapstructure:"max_queue"`
 	// ThrottleRetry is the failedCount threshold before sending to DLQ

--- a/internal/app/delivery/http/controllers/webhook_controller.go
+++ b/internal/app/delivery/http/controllers/webhook_controller.go
@@ -65,7 +65,7 @@ func (ctrl *WebhookController) HandleEnqueueWebHook(w http.ResponseWriter, r *ht
 		utils.BuildErrorResponse(ctrl.Log, w, exceptions.ErrClientCustomMessage(exceptions.BuildNewCustomError(nil, constvars.StatusBadRequest, "Invalid service name", "WEBHOOK_INVALID_SERVICE_NAME")))
 		return
 	}
-	if ok, _ := regexp.MatchString(`^[A-Za-z0-9]+$`, serviceName); !ok {
+	if ok, _ := regexp.MatchString(`^[A-Za-z0-9-]+$`, serviceName); !ok {
 		utils.BuildErrorResponse(ctrl.Log, w, exceptions.ErrClientCustomMessage(exceptions.BuildNewCustomError(nil, constvars.StatusBadRequest, "Invalid service name", "WEBHOOK_INVALID_SERVICE_NAME")))
 		return
 	}

--- a/internal/app/services/core/payments/payment_usecase_impl.go
+++ b/internal/app/services/core/payments/payment_usecase_impl.go
@@ -394,7 +394,7 @@ func (uc *paymentUsecase) callInstantiateURI(ctx context.Context, url string, bo
 	req.Header.Set(constvars.HeaderContentType, constvars.MIMEApplicationJSON)
 	// Attach internal forwarded JWT so webhook endpoint can bypass external auth
 	if uc.JWTManager != nil {
-		if out, err := uc.JWTManager.CreateToken(ctx, &jwtmanager.CreateTokenInput{Subject: "payment-service"}); err == nil {
+		if out, err := uc.JWTManager.CreateToken(ctx, &jwtmanager.CreateTokenInput{Subject: webhook.PAYMENT_SERVICE_SUB}); err == nil {
 			req.Header.Set(webhook.JWTForwardedFromPaymentServiceHeader, out.Token)
 		}
 	}

--- a/internal/app/services/core/webhook/auth_helper.go
+++ b/internal/app/services/core/webhook/auth_helper.go
@@ -122,7 +122,7 @@ func (u *usecase) evaluateWebhookAuth(ctx context.Context, in *evaluateAuthInput
 
 	// If service must be forwarded-only and no header provided
 	if mustBeForwarded {
-		return exceptions.BuildNewCustomError(nil, constvars.StatusUnauthorized, "missing required authentication for this service", "UNAUTHORIZED_WEBHOOK_CALLER")
+		return exceptions.BuildNewCustomError(nil, constvars.StatusPaymentRequired, "payment required to access this service", "PAYMENT_REQUIRED_FOR_SERVICE")
 	}
 
 	// Fallback to API key / session rules

--- a/internal/app/services/core/webhook/auth_helper.go
+++ b/internal/app/services/core/webhook/auth_helper.go
@@ -22,9 +22,9 @@ type ExtractAuthContextOutput struct {
 	IsSuperadmin bool
 }
 
-// ExtractAuthContext reads values set by APIKeyAuth and SessionOptional middlewares.
+// extractAuthContext reads values set by APIKeyAuth and SessionOptional middlewares.
 // It does not perform any I/O and is safe to call in controllers/handlers.
-func ExtractAuthContext(ctx context.Context) *ExtractAuthContextOutput {
+func (u *usecase) extractAuthContext(ctx context.Context) *ExtractAuthContextOutput {
 	out := &ExtractAuthContextOutput{
 		UID:   "",
 		Roles: []string{},
@@ -69,8 +69,30 @@ func ExtractAuthContext(ctx context.Context) *ExtractAuthContextOutput {
 	return out
 }
 
-// EvaluateWebhookAuth returns nil if authorized. It supports forwarded JWT header or falls back to API key/session.
-func EvaluateWebhookAuth(ctx context.Context, log *zap.Logger, jwtMgr *jwtmanager.JWTManager, forwardedJWT string) error {
+// evaluateAuthInput encapsulates inputs needed to evaluate webhook auth.
+type evaluateAuthInput struct {
+	ServiceName  string
+	ForwardedJWT string
+}
+
+// evaluateWebhookAuth returns nil if authorized. It supports forwarded JWT header or falls back to API key/session.
+func (u *usecase) evaluateWebhookAuth(ctx context.Context, in *evaluateAuthInput) error {
+	serviceName := in.ServiceName
+	forwardedJWT := in.ForwardedJWT
+	jwtMgr := u.jwtManager
+	log := u.log
+	paidOnlyServicesCSV := u.cfg.Webhook.PaidOnlyServices
+
+	// Normalize paid-only services
+	mustBeForwarded := false
+	if s := strings.TrimSpace(paidOnlyServicesCSV); s != "" {
+		for _, it := range strings.Split(s, ",") {
+			if strings.EqualFold(strings.TrimSpace(it), serviceName) {
+				mustBeForwarded = true
+				break
+			}
+		}
+	}
 	// Forwarded JWT path
 	if strings.TrimSpace(forwardedJWT) != "" {
 		out, err := jwtMgr.VerifyToken(ctx, &jwtmanager.VerifyTokenInput{Token: forwardedJWT})
@@ -79,21 +101,32 @@ func EvaluateWebhookAuth(ctx context.Context, log *zap.Logger, jwtMgr *jwtmanage
 			if log != nil {
 				log.Info("webhook auth: forwarded JWT invalid",
 					zap.String(constvars.LoggingRequestIDKey, requestID),
-					zap.Error(err),
 				)
 			}
 			return exceptions.BuildNewCustomError(nil, constvars.StatusUnauthorized, "Not authorized", "UNAUTHORIZED_WEBHOOK_CALLER")
 		}
+		// Enforce expected subject for payment-originated requests
+		if sub, ok := out.Claims["sub"].(string); !ok || !strings.EqualFold(sub, PAYMENT_SERVICE_SUB) {
+			if log != nil {
+				log.Info("webhook auth: forwarded JWT subject mismatch",
+					zap.String(constvars.LoggingRequestIDKey, requestID),
+				)
+			}
+			return exceptions.BuildNewCustomError(nil, constvars.StatusUnauthorized, "Not authorized", "INVALID_AUTH_CLAIM")
+		}
 		if log != nil {
-			log.Info("webhook auth: forwarded JWT valid",
-				zap.String(constvars.LoggingRequestIDKey, requestID),
-			)
+			log.Info("webhook auth: forwarded JWT valid")
 		}
 		return nil
 	}
 
+	// If service must be forwarded-only and no header provided
+	if mustBeForwarded {
+		return exceptions.BuildNewCustomError(nil, constvars.StatusUnauthorized, "missing required authentication for this service", "UNAUTHORIZED_WEBHOOK_CALLER")
+	}
+
 	// Fallback to API key / session rules
-	info := ExtractAuthContext(ctx)
+	info := u.extractAuthContext(ctx)
 	if info == nil {
 		return exceptions.BuildNewCustomError(nil, constvars.StatusUnauthorized, "Not authorized", "UNAUTHORIZED_WEBHOOK_CALLER")
 	}

--- a/internal/app/services/core/webhook/webhook_usecase_impl.go
+++ b/internal/app/services/core/webhook/webhook_usecase_impl.go
@@ -46,6 +46,9 @@ type EnqueueOutput struct{}
 // ensure the request comes from trusted payment service.
 const JWTForwardedFromPaymentServiceHeader = "X-Forwarded-From-Payment-Service"
 
+// PAYMENT_SERVICE_SUB is the expected JWT subject for forwarded requests from payment service
+const PAYMENT_SERVICE_SUB = "payment-service"
+
 // Enqueue validates, rate-limits, and enqueues the message.
 func (u *usecase) Enqueue(ctx context.Context, in *EnqueueInput) (*EnqueueOutput, error) {
 	requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)

--- a/internal/app/services/core/webhook/webhook_usecase_impl.go
+++ b/internal/app/services/core/webhook/webhook_usecase_impl.go
@@ -65,7 +65,7 @@ func (u *usecase) Enqueue(ctx context.Context, in *EnqueueInput) (*EnqueueOutput
 			forwarded = s
 		}
 	}
-	if err := EvaluateWebhookAuth(ctx, u.log, u.jwtManager, forwarded); err != nil {
+	if err := u.evaluateWebhookAuth(ctx, &evaluateAuthInput{ServiceName: in.ServiceName, ForwardedJWT: forwarded}); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Make a certain services can only be requested as a paid service

## Purpose 

Only allow a service to be requested from a successful payment by checking the service name against a list of service names that must be accessed after a payment has been made. If the service requested is match with the paid only service, check the proper authorization to ensure that the request comes from a trusted service indicated by the use of a special JWT token in header

## Configuration

To control which service can only be accessed by paid client, use this env keys:

- `HOOK_PAID_ONLY_SERVICES` (comma separated string, e.g: "analyze,report,performance-report")

## Testing

When requesting one of the `HOOK_PAID_ONLY_SERVICES` directly without paying, the request simply got denied.
`request`
<pre>
curl --request POST \
  --url http://localhost:8000/api/v1/hook/analyze \
  --header 'Content-Type: application/json' \
  --header 'User-Agent: insomnia/11.6.1' \
  --data '{
  "body": {
    "msg": "async"
  --- rest of the body
}'
</pre>

`response`
<pre>
{
	"status_code": 401,
	"success": false,
	"message": "missing required authentication for this service",
	"dev_message": "UNAUTHORIZED_WEBHOOK_CALLER",
	"locations": [
		{
			"file": "/home/lucky/project/be-konsulin/internal/app/services/core/webhook/webhook_usecase_impl.go",
			"line": 68,
			"function_name": "konsulin-service/internal/app/services/core/webhook.(*usecase).Enqueue"
		}
	]
}
</pre>

however, when first requesting the service using the same service name through the payment service, the request is received and eventually forwarded to n8n

`request`
<pre>
curl --request POST \
  --url http://localhost:8000/api/v1/pay/service \
  --header 'Content-Type: application/json' \
  --header 'x-api-key: password' \
  --data '{
    "total_item": 100,
    "service": "analyze",
    "body": {"msg": "async", "email": "mail@luckyakbar.web.id", "duplicate": "ohyeah"}
}'
</pre>

then, pay the service, and the request get forwarded to the n8n
`log`
<pre>
{"level":"INFO","time":"2025/09/27 07:57:25","caller":"webhookqueue/webhook_queue_service.go:246","msg":"WebhookQueue.FetchN called","request_id":""}
{"level":"INFO","time":"2025/09/27 07:57:25","caller":"webhook/worker.go:114","msg":"queue.FetchN success","fetched_count":1}
{"level":"INFO","time":"2025/09/27 07:57:25","caller":"jwtmanager/jwt_manager.go:109","msg":"JWTManager.CreateToken called","request_id":""}
{"level":"INFO","time":"2025/09/27 07:57:25","caller":"webhook/worker.go:146","msg":"forwarding webhook request","service_name":"analyze","message_id":"61d9b039-c95f-4718-8822-465304ed398c","method":"POST","url":"https://flow.konsulin.care/webhook/staging/analyze","failed_count":0}
{"level":"INFO","time":"2025/09/27 07:57:26","caller":"webhook/worker.go:164","msg":"webhook response received","service_name":"analyze","message_id":"61d9b039-c95f-4718-8822-465304ed398c","status_code":201}
</pre>