### PR TITLE
fix: configure supertoken cookie to work properly on local / dev environment

### DIFF
--- a/internal/app/services/core/auth/auth_supertoken_impl.go
+++ b/internal/app/services/core/auth/auth_supertoken_impl.go
@@ -34,9 +34,13 @@ func (uc *authUsecase) InitializeSupertoken() error {
 	apiBasePath := fmt.Sprintf("%s/%s%s", uc.InternalConfig.App.EndpointPrefix, uc.InternalConfig.App.Version, uc.DriverConfig.Supertoken.ApiBasePath)
 	websiteBasePath := uc.DriverConfig.Supertoken.WebsiteBasePath
 	cookieSameSite := constvars.CookieSameSiteStrictMode
+	cookieSecure := true
+	cookieDomain := uc.InternalConfig.App.FrontendDomain
 
 	if uc.InternalConfig.App.Env == "local" || uc.InternalConfig.App.Env == "development" {
-		cookieSameSite = constvars.CookieSameSiteNoneMode
+		cookieSameSite = constvars.CookieSameSiteLaxMode
+		cookieSecure = false
+		cookieDomain = ""
 	}
 
 	supertokenConnectionInfo := &supertokens.ConnectionInfo{
@@ -299,6 +303,8 @@ func (uc *authUsecase) InitializeSupertoken() error {
 				},
 			},
 			CookieSameSite: &cookieSameSite,
+			CookieSecure:   &cookieSecure,
+			CookieDomain:   &cookieDomain,
 		}),
 		dashboard.Init(&dashboardmodels.TypeInput{
 			Admins: &[]string{


### PR DESCRIPTION
## Summary

Use proper cookie values to ensure supertoken work properly on local setup on plain HTTP

## Purpose

To make locally running frontend app able to perform authentication using supertoken despite running on top of plain HTTP by using cookie same site `lax` policy. This PR aims to resolve [this issue](https://github.com/konsulin-care/konsulin-api/issues/197).

## Configuration

This PR didn't introduce any new configuration. However, the cookie same site lax policy will only be applied if value of `APP_ENV` is `local` or `development`.

## Testing

The testing process begin by running the app's dependencies using docker and then run the API server. After that, run the frontend app and try to sign up / sign in. Below are the view after clicking the magic link sent by supertoken to user's email

<img width="942" height="954" alt="image" src="https://github.com/user-attachments/assets/acf643a3-542f-498a-bbbf-988b5a1b16c1" />

## Note

This fix will require small changes to be applied to the frontend code, and the PR to the changes for that will be linked here after resolving repo permission issue.

Closes #197