### PR TITLE
Fix SuperTokens cookies for local/staging: remove Cookie Domain; use use host-only cookies

### DIFF
--- a/internal/app/services/core/auth/auth_supertoken_impl.go
+++ b/internal/app/services/core/auth/auth_supertoken_impl.go
@@ -35,12 +35,10 @@ func (uc *authUsecase) InitializeSupertoken() error {
 	websiteBasePath := uc.DriverConfig.Supertoken.WebsiteBasePath
 	cookieSameSite := constvars.CookieSameSiteStrictMode
 	cookieSecure := true
-	cookieDomain := uc.InternalConfig.App.FrontendDomain
 
 	if uc.InternalConfig.App.Env == "local" || uc.InternalConfig.App.Env == "development" {
 		cookieSameSite = constvars.CookieSameSiteLaxMode
 		cookieSecure = false
-		cookieDomain = ""
 	}
 
 	supertokenConnectionInfo := &supertokens.ConnectionInfo{
@@ -304,7 +302,6 @@ func (uc *authUsecase) InitializeSupertoken() error {
 			},
 			CookieSameSite: &cookieSameSite,
 			CookieSecure:   &cookieSecure,
-			CookieDomain:   &cookieDomain,
 		}),
 		dashboard.Init(&dashboardmodels.TypeInput{
 			Admins: &[]string{


### PR DESCRIPTION
## Summary

Only set Domain in future if cross-subdomain needed (use parent like .domain.com over HTTPS).

## Purpose

the changes before, setting the cookie domain, was causing issue when frontend making calls to supertoken's endpoint

<img width="812" height="435" alt="image" src="https://github.com/user-attachments/assets/d28cee23-8531-48bd-922c-5c9ba27ad0ed" />

## Note

the supertoken auth on local still works as expected