### PR TITLE
fix: fallback to read the first email segment if patient name is empty

### DIFF
--- a/internal/pkg/fhir_dto/patient.go
+++ b/internal/pkg/fhir_dto/patient.go
@@ -1,6 +1,8 @@
 package fhir_dto
 
-import "strings"
+import (
+	"strings"
+)
 
 type Patient struct {
 	ID           string         `json:"id,omitempty"`
@@ -19,6 +21,16 @@ type Patient struct {
 // Preference: official > usual > first; prefer Text, else Prefix+Given+Family.
 func (p Patient) FullName() string {
 	if len(p.Name) == 0 {
+		emails := p.GetEmailAddresses()
+		for _, email := range emails {
+			if strings.Contains(email, "@") {
+				firstPart := strings.Split(email, "@")[0]
+				if firstPart != "" {
+					return firstPart
+				}
+			}
+		}
+
 		return ""
 	}
 	chosen := p.Name[0]


### PR DESCRIPTION
This was made to further prevent empty username causing error or payment services. Currently, when a new user signs up, their name field on Patient resource is empty. Below is the example

<pre>
{
	...,
	"entry": [
		{
			"fullUrl": "http://localhost:8080/fhir/Patient/DGTIOF7ZHNNG2BJN",
			"resource": {
				"resourceType": "Patient",
				"id": "DGTIOF7ZHNNG2BJN",
				"meta": {
					"versionId": "972",
					"lastUpdated": "2025-11-09T11:47:40.130Z"
				},
				"identifier": [
					{
						"system": "https://login.konsulin.care/userid",
						"value": "1da47571-047f-4faa-a58b-a80914440fb8"
					}
				],
				"active": true,
				"telecom": [
					{
						"system": "email",
						"value": "samplename@gmail.com",
						"use": "home"
					}
				]
			},
			"search": {
				"mode": "match"
			}
		}
	]
}
</pre>


That can cause error on xendit payment like below:
<pre>
{
	"status_code": 400,
	"success": false,
	"message": "Invalid input data. Please check your request",
	"dev_message": "xendit error code=API_VALIDATION_ERROR message=Invalid input data. Please check your request: xendit error code=API_VALIDATION_ERROR message=Invalid input data. Please check your request",
	"locations": [
		{
			"file": "/home/lucky/project/be-konsulin/internal/app/services/core/payments/payment_usecase_impl.go",
			"line": 619,
			"function_name": "konsulin-service/internal/app/services/core/payments.(*paymentUsecase).CreatePay"
		}
	]
}
</pre>

<pre>
{
  "level": "ERROR",
  "time": "2025/11/09 12:28:33",
  "caller": "utils/response.go:69",
  "msg": "xendit error code=API_VALIDATION_ERROR message=Invalid input data. Please check your request: xendit error code=API_VALIDATION_ERROR message=Invalid input data. Please check your request",
  "location": {
    "file": "/home/lucky/project/be-konsulin/internal/app/services/core/payments/payment_usecase_impl.go",
    "function_name": "konsulin-service/internal/app/services/core/payments.(*paymentUsecase).CreatePay",
    "line": 619
  }
}
</pre>

By applying this changes, it is basically guaranteed that the user's Patient name will never be empty because the email field in telecom will always be populated since the beginning.

now, the payment successfully created despite the Patient data still missing a valid entry on `name` field.

<img width="1919" height="1026" alt="image" src="https://github.com/user-attachments/assets/ef122462-a6c5-4f2e-b704-3f87d7f03a4e" />
