### PR TITLE
Refactor Dependabot groups for update types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,17 +11,19 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      update-types:
-        - "minor"
-        - "patch"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
     groups:
-      update-types:
-        - "minor"
-        - "patch"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -29,6 +31,7 @@ updates:
     allow:
       - dependency-type: "direct"
     groups:
-      update-types:
-        - "minor"
-        - "patch"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Restructure Dependabot groups with named group wrapper

- Add `minor-and-patch` group name for better organization

- Nest `update-types` configuration under group names

- Apply changes consistently across docker, github-actions, and gomod ecosystems


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["update-types config"] -->|refactored to| B["minor-and-patch group"]
  B -->|contains| C["update-types list"]
  C -->|applied to| D["docker, github-actions, gomod"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Restructure Dependabot groups with semantic naming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Renamed <code>update-types</code> group to <code>minor-and-patch</code> for clarity<br> <li> Nested <code>update-types</code> configuration under the new group name<br> <li> Applied consistent restructuring to all three package ecosystems<br> <li> Maintains same update type filtering (minor and patch versions)</ul>


</details>


  </td>
  <td><a href="https://github.com/konsulin-care/konsulin-api/pull/265/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+12/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

