### PR TITLE
feat: allow superadmin role to access appointment payment api

### DIFF
--- a/internal/app/services/core/payments/payment_usecase_impl.go
+++ b/internal/app/services/core/payments/payment_usecase_impl.go
@@ -997,7 +997,7 @@ func (uc *paymentUsecase) HandleAppointmentPayment(
 	ctx context.Context,
 	req *requests.AppointmentPaymentRequest,
 ) (*responses.AppointmentPaymentResponse, error) {
-	if !uc.whitelistAccessByRoles(ctx, []string{constvars.KonsulinRolePatient}) {
+	if !uc.whitelistAccessByRoles(ctx, []string{constvars.KonsulinRolePatient, constvars.KonsulinRoleSuperadmin}) {
 		return nil, exceptions.ErrAuthInvalidRole(errors.New("forbidden access"))
 	}
 
@@ -1202,6 +1202,8 @@ func (uc *paymentUsecase) ensurePreconditionsValid(
 ) (*preconditionData, error) {
 	requestID, _ := ctx.Value(constvars.CONTEXT_REQUEST_ID_KEY).(string)
 	uid, _ := ctx.Value(constvars.CONTEXT_UID).(string)
+	roles, _ := ctx.Value(constvars.CONTEXT_FHIR_ROLE).([]string)
+	isSuperadmin := slices.Contains(roles, constvars.KonsulinRoleSuperadmin)
 
 	slotID := strings.TrimPrefix(req.SlotID, "Slot/")
 	practitionerRoleID := strings.TrimPrefix(req.PractitionerRoleID, "PractitionerRole/")
@@ -1250,7 +1252,7 @@ func (uc *paymentUsecase) ensurePreconditionsValid(
 				break
 			}
 		}
-		if !match {
+		if !isSuperadmin && !match {
 			return &resourceFetchError{resource: "patient", err: errors.New("patient ID does not match with the current user")}
 		}
 		fetchedPatient = p


### PR DESCRIPTION
## Purpose

Make requester with role `superadmin` able to access appointment payment API and make appointment on the user's behalf

## Adjustments

This changes includde several adjustments on the appointment api logic, including:
- make `superadmin` role allowed to access this API from the whitelisted roles
- skip patient-id and the requester id sameness check to ensure `superadmin` can act on user's behalf

Other safety and checks isn't changed.

## Testing

I test this changes by making appointment as a Patient and as a `superadmin`

### Make an appointment as a Patient

<img width="661" height="860" alt="image" src="https://github.com/user-attachments/assets/23717714-d980-498a-bcb9-da30f1b87af7" />

<img width="646" height="859" alt="image" src="https://github.com/user-attachments/assets/9c33515c-4561-4fce-b7a8-94eefb64c163" />

<img width="651" height="737" alt="image" src="https://github.com/user-attachments/assets/76897326-e732-4fbd-afd9-81bb9b3c38f3" />

<img width="1344" height="857" alt="image" src="https://github.com/user-attachments/assets/e557c03e-bb33-40da-8c8f-a91a7c1c26bc" />

<img width="647" height="859" alt="image" src="https://github.com/user-attachments/assets/e14dd5b1-8091-46a6-a3a4-b59146e28ea0" />

### Make an appointment as a `superadmin`

<img width="1156" height="836" alt="image" src="https://github.com/user-attachments/assets/2965c1c5-a503-48ee-845f-9be227ad3fa1" />

<img width="1512" height="866" alt="image" src="https://github.com/user-attachments/assets/087d9418-4a3c-4b51-9fa6-d34d9c022033" />

<img width="673" height="774" alt="image" src="https://github.com/user-attachments/assets/680e7d2e-b2d0-4495-8142-1b84d8ad2640" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Superadmins can now process appointment payments and manage payments across all patient accounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->