### PR TITLE
Fix/optional name and email for xendit payment

### DIFF
--- a/internal/app/services/core/payments/payment_usecase_impl.go
+++ b/internal/app/services/core/payments/payment_usecase_impl.go
@@ -725,29 +725,37 @@ func (uc *paymentUsecase) createXenditInvoiceForAppointment(
 	customer := xinvoice.NewCustomerObject()
 	customer.SetGivenNames(patientName)
 
-	prefferedNotificationChannel := []xinvoice.NotificationChannel{}
+	preferredNotificationChannel := []xinvoice.NotificationChannel{}
 
 	if patientEmail != "" {
 		customer.SetEmail(patientEmail)
-		prefferedNotificationChannel = append(prefferedNotificationChannel, xinvoice.NOTIFICATIONCHANNEL_EMAIL)
+		preferredNotificationChannel = append(
+			preferredNotificationChannel,
+			xinvoice.NOTIFICATIONCHANNEL_EMAIL,
+		)
 	}
 
 	if patientPhoneNumber != "" {
 		customer.SetMobileNumber(patientPhoneNumber)
 		customer.SetPhoneNumber(patientPhoneNumber)
 
-		prefferedNotificationChannel = append(prefferedNotificationChannel, xinvoice.NOTIFICATIONCHANNEL_SMS)
-		prefferedNotificationChannel = append(prefferedNotificationChannel, xinvoice.NOTIFICATIONCHANNEL_WHATSAPP)
+		preferredNotificationChannel = append(
+			preferredNotificationChannel,
+			xinvoice.NOTIFICATIONCHANNEL_SMS,
+			xinvoice.NOTIFICATIONCHANNEL_WHATSAPP,
+		)
 	}
 
 	invoiceReq.SetCustomer(*customer)
 
-	notif := xinvoice.NewNotificationPreference()
-	notif.SetInvoiceCreated(prefferedNotificationChannel)
-	notif.SetInvoicePaid(prefferedNotificationChannel)
-	notif.SetInvoiceReminder(prefferedNotificationChannel)
+	if len(preferredNotificationChannel) != 0 {
+		notif := xinvoice.NewNotificationPreference()
+		notif.SetInvoiceCreated(preferredNotificationChannel)
+		notif.SetInvoicePaid(preferredNotificationChannel)
+		notif.SetInvoiceReminder(preferredNotificationChannel)
 
-	invoiceReq.SetCustomerNotificationPreference(*notif)
+		invoiceReq.SetCustomerNotificationPreference(*notif)
+	}
 
 	item := xinvoice.NewInvoiceItem("Pembayaran Janji Temu", float32(amount), float32(1))
 	invoiceReq.SetItems([]xinvoice.InvoiceItem{*item})

--- a/internal/app/services/core/payments/payment_usecase_impl.go
+++ b/internal/app/services/core/payments/payment_usecase_impl.go
@@ -699,7 +699,11 @@ func (uc *paymentUsecase) createXenditInvoiceForAppointment(
 	if len(patientEmails) > 0 {
 		patientEmail = patientEmails[0]
 	}
+
 	patientName := precond.Patient.FullName()
+	if patientName == "" {
+		patientName = "Pasien Konsulin"
+	}
 
 	durationSeconds := float32(uc.InternalConfig.App.PaymentExpiredTimeInMinutes * 60)
 
@@ -714,7 +718,11 @@ func (uc *paymentUsecase) createXenditInvoiceForAppointment(
 
 	customer := xinvoice.NewCustomerObject()
 	customer.SetGivenNames(patientName)
-	customer.SetEmail(patientEmail)
+
+	if patientEmail != "" {
+		customer.SetEmail(patientEmail)
+	}
+
 	invoiceReq.SetCustomer(*customer)
 
 	notif := xinvoice.NewNotificationPreference()

--- a/internal/app/services/core/payments/payment_usecase_impl.go
+++ b/internal/app/services/core/payments/payment_usecase_impl.go
@@ -700,6 +700,12 @@ func (uc *paymentUsecase) createXenditInvoiceForAppointment(
 		patientEmail = patientEmails[0]
 	}
 
+	patientPhoneNumbers := precond.Patient.GetPhoneNumbers()
+	var patientPhoneNumber string
+	if len(patientPhoneNumbers) > 0 {
+		patientPhoneNumber = patientPhoneNumbers[0]
+	}
+
 	patientName := precond.Patient.FullName()
 	if patientName == "" {
 		patientName = "Pasien Konsulin"
@@ -719,15 +725,28 @@ func (uc *paymentUsecase) createXenditInvoiceForAppointment(
 	customer := xinvoice.NewCustomerObject()
 	customer.SetGivenNames(patientName)
 
+	prefferedNotificationChannel := []xinvoice.NotificationChannel{}
+
 	if patientEmail != "" {
 		customer.SetEmail(patientEmail)
+		prefferedNotificationChannel = append(prefferedNotificationChannel, xinvoice.NOTIFICATIONCHANNEL_EMAIL)
+	}
+
+	if patientPhoneNumber != "" {
+		customer.SetMobileNumber(patientPhoneNumber)
+		customer.SetPhoneNumber(patientPhoneNumber)
+
+		prefferedNotificationChannel = append(prefferedNotificationChannel, xinvoice.NOTIFICATIONCHANNEL_SMS)
+		prefferedNotificationChannel = append(prefferedNotificationChannel, xinvoice.NOTIFICATIONCHANNEL_WHATSAPP)
 	}
 
 	invoiceReq.SetCustomer(*customer)
 
 	notif := xinvoice.NewNotificationPreference()
-	notif.SetInvoiceCreated([]xinvoice.NotificationChannel{xinvoice.NOTIFICATIONCHANNEL_EMAIL})
-	notif.SetInvoicePaid([]xinvoice.NotificationChannel{xinvoice.NOTIFICATIONCHANNEL_EMAIL})
+	notif.SetInvoiceCreated(prefferedNotificationChannel)
+	notif.SetInvoicePaid(prefferedNotificationChannel)
+	notif.SetInvoiceReminder(prefferedNotificationChannel)
+
 	invoiceReq.SetCustomerNotificationPreference(*notif)
 
 	item := xinvoice.NewInvoiceItem("Pembayaran Janji Temu", float32(amount), float32(1))

--- a/resources/rbac_policy.csv
+++ b/resources/rbac_policy.csv
@@ -122,5 +122,6 @@ p, Superadmin, GET, /fhir/Schedule
 p, Superadmin, POST, /fhir/Schedule
 p, Superadmin, GET, /fhir/Slot
 p, Superadmin, PUT, /fhir/Slot
+p, Superadmin, GET, /fhir/Patient
 p, Superadmin, GET, /fhir/metadata
 p, Superadmin, GET, /api/v1/tx


### PR DESCRIPTION
## Purpose

Making changes to allow xendit payment request omit user's email if it is empty and use default value for username if that is also empty

## Adjustment List

- use default value for username if user's name in the Patient resource is empty
- allow superadmin role to perform READ to Patient resource to allow superadmin to ensure user's resource exists before creating appointment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Payment invoice creation now better handles missing patient contact info so invoices are generated reliably using available fallback details.
* **New Features**
  * Notification delivery adapts to available contact methods (email, SMS/WhatsApp) and now sends invoice reminders in addition to creation and payment alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->