### PR TITLE
Fix/add missing permission for superadmin create patient

### DIFF
--- a/internal/app/delivery/http/routers/auth_router_test.go
+++ b/internal/app/delivery/http/routers/auth_router_test.go
@@ -77,6 +77,15 @@ func (m *MockAuthUsecase) CheckUserExistsByPhone(ctx context.Context, phone stri
 	return out, args.Error(1)
 }
 
+func (m *MockAuthUsecase) ClaimAnonymousResources(ctx context.Context, supertokensUserID string, roles []string, anonToken string) (*contracts.ClaimAnonymousResourcesOutput, error) {
+	args := m.Called(ctx, supertokensUserID, roles, anonToken)
+	var out *contracts.ClaimAnonymousResourcesOutput
+	if v := args.Get(0); v != nil {
+		out = v.(*contracts.ClaimAnonymousResourcesOutput)
+	}
+	return out, args.Error(1)
+}
+
 func TestAuthRouter_MagicLinkEndpoint(t *testing.T) {
 	logger := zap.NewNop()
 
@@ -89,7 +98,7 @@ func TestAuthRouter_MagicLinkEndpoint(t *testing.T) {
 
 	mockAuthUsecase := new(MockAuthUsecase)
 
-	authController := &controllers.AuthController{Log: logger, AuthUsecase: mockAuthUsecase}
+	authController := &controllers.AuthController{Log: logger, AuthUsecase: mockAuthUsecase, InternalConfig: internalConfig}
 
 	middlewareInstance := &middlewares.Middlewares{
 		Log:            logger,
@@ -246,7 +255,7 @@ func TestAuthRouter_ContextPropagation(t *testing.T) {
 
 	mockAuthUsecase := new(MockAuthUsecase)
 
-	authController := &controllers.AuthController{Log: logger, AuthUsecase: mockAuthUsecase}
+	authController := &controllers.AuthController{Log: logger, AuthUsecase: mockAuthUsecase, InternalConfig: internalConfig}
 
 	middlewareInstance := &middlewares.Middlewares{
 		Log:            logger,
@@ -320,7 +329,7 @@ func TestAuthRouter_ErrorHandling(t *testing.T) {
 
 	mockAuthUsecase := new(MockAuthUsecase)
 
-	authController := &controllers.AuthController{Log: logger, AuthUsecase: mockAuthUsecase}
+	authController := &controllers.AuthController{Log: logger, AuthUsecase: mockAuthUsecase, InternalConfig: internalConfig}
 
 	middlewareInstance := &middlewares.Middlewares{
 		Log:            logger,

--- a/resources/rbac_policy.csv
+++ b/resources/rbac_policy.csv
@@ -125,3 +125,4 @@ p, Superadmin, PUT, /fhir/Slot
 p, Superadmin, GET, /fhir/Patient
 p, Superadmin, GET, /fhir/metadata
 p, Superadmin, GET, /api/v1/tx
+p, Superadmin, POST, /fhir/Patient


### PR DESCRIPTION
add missing permission to allow superadmin to create Patient resource

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with additional mock implementations and updated controller initialization patterns.

* **Chores**
  * Updated internal test configurations to support improved testing coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->